### PR TITLE
[DPE-2992] Part-1 Recieve keyfile from config-server

### DIFF
--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -1,0 +1,150 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""In this class, we manage relations between config-servers and shards.
+
+This class handles the sharing of secrets between sharded components, adding shards, and removing
+shards.
+"""
+import logging
+
+from ops.charm import CharmBase, EventBase
+from ops.framework import Object
+from ops.model import WaitingStatus
+
+from config import Config
+
+logger = logging.getLogger(__name__)
+KEYFILE_KEY = "key-file"
+KEY_FILE = "keyFile"
+HOSTS_KEY = "host"
+CONFIG_SERVER_URI_KEY = "config-server-uri"
+
+# The unique Charmhub library identifier, never change it
+LIBID = "58ad1ccca4974932ba22b97781b9b2a0"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+class ClusterProvider(Object):
+    """Manage relations between the config server and mongos router on the config-server side."""
+
+    def __init__(
+        self, charm: CharmBase, relation_name: str = Config.Relations.CLUSTER_RELATIONS_NAME
+    ) -> None:
+        """Constructor for ShardingProvider object."""
+        self.relation_name = relation_name
+        self.charm = charm
+
+        super().__init__(charm, self.relation_name)
+        self.framework.observe(
+            charm.on[self.relation_name].relation_joined, self._on_relation_joined
+        )
+
+        # TODO Future PRs handle scale down
+
+    def pass_hook_checks(self, event: EventBase) -> bool:
+        """Runs the pre-hooks checks for ClusterProvider, returns True if all pass."""
+        if not self.charm.is_role(Config.Role.CONFIG_SERVER):
+            logger.info(
+                "Skipping %s. ShardingProvider is only be executed by config-server", type(event)
+            )
+            return False
+
+        if not self.charm.unit.is_leader():
+            return False
+
+        if not self.charm.db_initialised:
+            logger.info("Deferring %s. db is not initialised.", type(event))
+            event.defer()
+            return False
+
+        return True
+
+    def _on_relation_joined(self, event):
+        """Handles providing mongos with KeyFile and hosts."""
+        if not self.pass_hook_checks(event):
+            logger.info("Skipping relation joined event: hook checks did not pass")
+            return
+
+        # TODO Future PR, provide URI
+        # TODO Future PR, use secrets
+        self._update_relation_data(
+            event.relation.id,
+            {
+                KEYFILE_KEY: self.charm.get_secret(
+                    Config.Relations.APP_SCOPE, Config.Secrets.SECRET_KEYFILE_NAME
+                ),
+            },
+        )
+
+    def _update_relation_data(self, relation_id: int, data: dict) -> None:
+        """Updates a set of key-value pairs in the relation.
+
+        This function writes in the application data bag, therefore, only the leader unit can call
+        it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            data: dict containing the key-value pairs
+                that should be updated in the relation.
+        """
+        if self.charm.unit.is_leader():
+            relation = self.charm.model.get_relation(self.relation_name, relation_id)
+            if relation:
+                relation.data[self.charm.model.app].update(data)
+
+
+class ClusterRequirer(Object):
+    """Manage relations between the config server and mongos router on the mongos side."""
+
+    def __init__(
+        self, charm: CharmBase, relation_name: str = Config.Relations.CLUSTER_RELATIONS_NAME
+    ) -> None:
+        """Constructor for ShardingProvider object."""
+        self.relation_name = relation_name
+        self.charm = charm
+
+        super().__init__(charm, self.relation_name)
+        self.framework.observe(
+            charm.on[self.relation_name].relation_changed, self._on_relation_changed
+        )
+        # TODO Future PRs handle scale down
+
+    def _on_relation_changed(self, event):
+        """Starts/restarts monogs with config server information."""
+        relation_data = event.relation.data[event.app]
+        if not relation_data.get(KEYFILE_KEY):
+            event.defer()
+            self.charm.unit.status = WaitingStatus("Waiting for secrets from config-server")
+            return
+
+        self.update_keyfile(key_file_contents=relation_data.get(KEYFILE_KEY))
+
+        # TODO: Follow up PR. Start mongos with the config-server URI
+        # TODO: Follow up PR. Add a user for mongos once it has been started
+
+    def update_keyfile(self, key_file_contents: str) -> None:
+        """Updates keyfile on all units."""
+        # keyfile is set by leader in application data, application data does not necessarily
+        # match what is on the machine.
+        current_key_file = self.charm.get_keyfile_contents()
+        if not key_file_contents or key_file_contents == current_key_file:
+            return
+
+        # put keyfile on the machine with appropriate permissions
+        self.charm.push_file_to_unit(
+            parent_dir=Config.MONGOD_CONF_DIR, file_name=KEY_FILE, file_contents=key_file_contents
+        )
+
+        if not self.charm.unit.is_leader():
+            return
+
+        self.charm.set_secret(
+            Config.Relations.APP_SCOPE, Config.Secrets.SECRET_KEYFILE_NAME, key_file_contents
+        )

--- a/lib/charms/mongodb/v0/mongodb_secrets.py
+++ b/lib/charms/mongodb/v0/mongodb_secrets.py
@@ -1,0 +1,137 @@
+"""Secrets related helper classes/functions."""
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from typing import Dict, Optional
+
+from ops import Secret, SecretInfo
+from ops.charm import CharmBase
+from ops.model import SecretNotFoundError
+
+from config import Config
+from exceptions import SecretAlreadyExistsError
+
+# The unique Charmhub library identifier, never change it
+
+# The unique Charmhub library identifier, never change it
+LIBID = "89cefc863fd747d7ace12cb508e7bec2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+APP_SCOPE = Config.Relations.APP_SCOPE
+UNIT_SCOPE = Config.Relations.UNIT_SCOPE
+Scopes = Config.Relations.Scopes
+
+
+def generate_secret_label(charm: CharmBase, scope: Scopes) -> str:
+    """Generate unique group_mappings for secrets within a relation context.
+
+    Defined as a standalone function, as the choice on secret labels definition belongs to the
+    Application Logic. To be kept separate from classes below, which are simply to provide a
+    (smart) abstraction layer above Juju Secrets.
+    """
+    members = [charm.app.name, scope]
+    return f"{'.'.join(members)}"
+
+
+# Secret cache
+
+
+class CachedSecret:
+    """Abstraction layer above direct Juju access with caching.
+
+    The data structure is precisely re-using/simulating Juju Secrets behavior, while
+    also making sure not to fetch a secret multiple times within the same event scope.
+    """
+
+    def __init__(self, charm: CharmBase, label: str, secret_uri: Optional[str] = None):
+        self._secret_meta = None
+        self._secret_content = {}
+        self._secret_uri = secret_uri
+        self.label = label
+        self.charm = charm
+
+    def add_secret(self, content: Dict[str, str], scope: Scopes) -> Secret:
+        """Create a new secret."""
+        if self._secret_uri:
+            raise SecretAlreadyExistsError(
+                "Secret is already defined with uri %s", self._secret_uri
+            )
+
+        if scope == Config.Relations.APP_SCOPE:
+            secret = self.charm.app.add_secret(content, label=self.label)
+        else:
+            secret = self.charm.unit.add_secret(content, label=self.label)
+        self._secret_uri = secret.id
+        self._secret_meta = secret
+        return self._secret_meta
+
+    @property
+    def meta(self) -> Optional[Secret]:
+        """Getting cached secret meta-information."""
+        if self._secret_meta:
+            return self._secret_meta
+
+        if not (self._secret_uri or self.label):
+            return
+
+        try:
+            self._secret_meta = self.charm.model.get_secret(label=self.label)
+        except SecretNotFoundError:
+            if self._secret_uri:
+                self._secret_meta = self.charm.model.get_secret(
+                    id=self._secret_uri, label=self.label
+                )
+        return self._secret_meta
+
+    def get_content(self) -> Dict[str, str]:
+        """Getting cached secret content."""
+        if not self._secret_content:
+            if self.meta:
+                self._secret_content = self.meta.get_content()
+        return self._secret_content
+
+    def set_content(self, content: Dict[str, str]) -> None:
+        """Setting cached secret content."""
+        if self.meta:
+            self.meta.set_content(content)
+            self._secret_content = content
+
+    def get_info(self) -> Optional[SecretInfo]:
+        """Wrapper function for get the corresponding call on the Secret object if any."""
+        if self.meta:
+            return self.meta.get_info()
+
+
+class SecretCache:
+    """A data structure storing CachedSecret objects."""
+
+    def __init__(self, charm):
+        self.charm = charm
+        self._secrets: Dict[str, CachedSecret] = {}
+
+    def get(self, label: str, uri: Optional[str] = None) -> Optional[CachedSecret]:
+        """Getting a secret from Juju Secret store or cache."""
+        if not self._secrets.get(label):
+            secret = CachedSecret(self.charm, label, uri)
+            if secret.meta:
+                self._secrets[label] = secret
+        return self._secrets.get(label)
+
+    def add(self, label: str, content: Dict[str, str], scope: Scopes) -> CachedSecret:
+        """Adding a secret to Juju Secret."""
+        if self._secrets.get(label):
+            raise SecretAlreadyExistsError(f"Secret {label} already exists")
+
+        secret = CachedSecret(self.charm, label)
+        secret.add_secret(content, scope)
+        self._secrets[label] = secret
+        return self._secrets[label]
+
+
+# END: Secret cache

--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -267,3 +267,23 @@ def process_pbm_status(pbm_status: str) -> StatusBase:
         return WaitingStatus("waiting to sync s3 configurations.")
 
     return ActiveStatus()
+
+
+def add_args_to_env(var: str, args: str):
+    """Adds the provided arguments to the environment as the provided variable."""
+    with open(Config.ENV_VAR_PATH, "r") as env_var_file:
+        env_vars = env_var_file.readlines()
+
+    args_added = False
+    for index, line in enumerate(env_vars):
+        if var in line:
+            args_added = True
+            env_vars[index] = f"{var}={args}"
+
+    # if it is the first time adding these args to the file - will will need to append them to the
+    # file
+    if not args_added:
+        env_vars.append(f"{var}={args}")
+
+    with open(Config.ENV_VAR_PATH, "w") as service_file:
+        service_file.writelines(env_vars)

--- a/lib/charms/mongodb/v1/mongos.py
+++ b/lib/charms/mongodb/v1/mongos.py
@@ -1,0 +1,461 @@
+"""Code for interactions with MongoDB."""
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Set, Tuple
+from urllib.parse import quote_plus
+
+from charms.mongodb.v0.mongodb import NotReadyError
+from pymongo import MongoClient, collection
+from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
+
+from config import Config
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e20d5b19670d4c55a4934a21d3f3b29a"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 4
+
+# path to store mongodb ketFile
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MongosConfiguration:
+    """Class for mongos configuration.
+
+    — database: database name.
+    — username: username.
+    — password: password.
+    — hosts: full list of hosts to connect to, needed for the URI.
+    - port: integer for the port to connect to connect to mongodb.
+    - tls_external: indicator for use of internal TLS connection.
+    - tls_internal: indicator for use of external TLS connection.
+    """
+
+    database: Optional[str]
+    username: str
+    password: str
+    hosts: Set[str]
+    port: int
+    roles: Set[str]
+    tls_external: bool
+    tls_internal: bool
+
+    @property
+    def uri(self):
+        """Return URI concatenated from fields."""
+        hosts = [f"{host}:{self.port}" for host in self.hosts]
+        hosts = ",".join(hosts)
+        # Auth DB should be specified while user connects to application DB.
+        auth_source = ""
+        if self.database != "admin":
+            auth_source = "&authSource=admin"
+        return (
+            f"mongodb://{quote_plus(self.username)}:"
+            f"{quote_plus(self.password)}@"
+            f"{hosts}/{quote_plus(self.database)}?"
+            f"{auth_source}"
+        )
+
+
+class NotEnoughSpaceError(Exception):
+    """Raised when there isn't enough space to movePrimary."""
+
+
+class ShardNotInClusterError(Exception):
+    """Raised when shard is not present in cluster, but it is expected to be."""
+
+
+class ShardNotPlannedForRemovalError(Exception):
+    """Raised when it is expected that a shard is planned for removal, but it is not."""
+
+
+class NotDrainedError(Exception):
+    """Raised when a shard is still being drained."""
+
+
+class BalancerNotEnabledError(Exception):
+    """Raised when balancer process is not enabled."""
+
+
+class MongosConnection:
+    """In this class we create connection object to Mongos.
+
+    Real connection is created on the first call to Mongos.
+    Delayed connectivity allows to firstly check database readiness
+    and reuse the same connection for an actual query later in the code.
+
+    Connection is automatically closed when object destroyed.
+    Automatic close allows to have more clean code.
+
+    Note that connection when used may lead to the following pymongo errors: ConfigurationError,
+    ConfigurationError, OperationFailure. It is suggested that the following pattern be adopted
+    when using MongoDBConnection:
+
+    with MongoMongos(self._mongos_config) as mongo:
+        try:
+            mongo.<some operation from this class>
+        except ConfigurationError, OperationFailure:
+            <error handling as needed>
+    """
+
+    def __init__(self, config: MongosConfiguration, uri=None, direct=False):
+        """A MongoDB client interface.
+
+        Args:
+            config: MongoDB Configuration object.
+            uri: allow using custom MongoDB URI, needed for replSet init.
+            direct: force a direct connection to a specific host, avoiding
+                    reading replica set configuration and reconnection.
+        """
+        self.mongodb_config = config
+
+        if uri is None:
+            uri = config.uri
+
+        self.client = MongoClient(
+            uri,
+            directConnection=direct,
+            connect=False,
+            serverSelectionTimeoutMS=1000,
+            connectTimeoutMS=2000,
+        )
+        return
+
+    def __enter__(self):
+        """Return a reference to the new connection."""
+        return self
+
+    def __exit__(self, object_type, value, traceback):
+        """Disconnect from MongoDB client."""
+        self.client.close()
+        self.client = None
+
+    def get_shard_members(self) -> Set[str]:
+        """Gets shard members.
+
+        Returns:
+            A set of the shard members as reported by mongos.
+
+        Raises:
+            ConfigurationError, OperationFailure
+        """
+        shard_list = self.client.admin.command("listShards")
+        curr_members = [
+            self._hostname_from_hostport(member["host"]) for member in shard_list["shards"]
+        ]
+        return set(curr_members)
+
+    def add_shard(self, shard_name, shard_hosts, shard_port=Config.MONGODB_PORT):
+        """Adds shard to the cluster.
+
+        Raises:
+            ConfigurationError, OperationFailure
+        """
+        shard_hosts = [f"{host}:{shard_port}" for host in shard_hosts]
+        shard_hosts = ",".join(shard_hosts)
+        shard_url = f"{shard_name}/{shard_hosts}"
+        if shard_name in self.get_shard_members():
+            logger.info("Skipping adding shard %s, shard is already in cluster", shard_name)
+            return
+
+        logger.info("Adding shard %s", shard_name)
+        self.client.admin.command("addShard", shard_url)
+
+    def pre_remove_checks(self, shard_name):
+        """Performs a series of checks for removing a shard from the cluster.
+
+        Raises
+            ConfigurationError, OperationFailure, NotReadyError, ShardNotInClusterError,
+            BalencerNotEnabledError
+        """
+        if shard_name not in self.get_shard_members():
+            logger.info("Shard to remove is not in cluster.")
+            raise ShardNotInClusterError(f"Shard {shard_name} could not be removed")
+
+        # It is necessary to call removeShard multiple times on a shard to guarantee removal.
+        # Allow re-removal of shards that are currently draining.
+        sc_status = self.client.admin.command("listShards")
+        if self._is_any_draining(sc_status, ignore_shard=shard_name):
+            cannot_remove_shard = (
+                f"cannot remove shard {shard_name} from cluster, another shard is draining"
+            )
+            logger.error(cannot_remove_shard)
+            raise NotReadyError(cannot_remove_shard)
+
+        # check if enabled sh.getBalancerState()
+        balancer_state = self.client.admin.command("balancerStatus")
+        if balancer_state["mode"] != "off":
+            logger.info("Balancer is enabled, ready to remove shard.")
+            return
+
+        # starting the balancer doesn't guarantee that is is running, wait until it starts up.
+        logger.info("Balancer process is not running, enabling it.")
+        self.client.admin.command("balancerStart")
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3), reraise=True):
+            with attempt:
+                balancer_state = self.client.admin.command("balancerStatus")
+                if balancer_state["mode"] == "off":
+                    raise BalancerNotEnabledError("balancer is not enabled.")
+
+    def remove_shard(self, shard_name: str) -> None:
+        """Removes shard from the cluster.
+
+        Raises:
+            ConfigurationError, OperationFailure, NotReadyError, NotEnoughSpaceError,
+            ShardNotInClusterError, BalencerNotEnabledError
+        """
+        self.pre_remove_checks(shard_name)
+
+        # remove shard, process removal status, & check if fully removed
+        logger.info("Attempting to remove shard %s", shard_name)
+        removal_info = self.client.admin.command("removeShard", shard_name)
+        self._log_removal_info(removal_info, shard_name)
+        remaining_chunks = self._retrieve_remaining_chunks(removal_info)
+        if remaining_chunks:
+            logger.info("Waiting for all chunks to be drained from %s.", shard_name)
+            raise NotDrainedError()
+
+        # MongoDB docs says to movePrimary only after all chunks have been drained from the shard.
+        logger.info("All chunks drained from shard: %s", shard_name)
+        databases_using_shard_as_primary = self.get_databases_for_shard(shard_name)
+        if databases_using_shard_as_primary:
+            logger.info(
+                "These databases: %s use Shard %s is a primary shard, moving primary.",
+                ", ".join(databases_using_shard_as_primary),
+                shard_name,
+            )
+            self._move_primary(databases_using_shard_as_primary, old_primary=shard_name)
+
+            # MongoDB docs says to re-run removeShard after running movePrimary
+            logger.info("removing shard: %s, after moving primary", shard_name)
+            removal_info = self.client.admin.command("removeShard", shard_name)
+            self._log_removal_info(removal_info, shard_name)
+
+        if shard_name in self.get_shard_members():
+            logger.info("Shard %s is still present in sharded cluster.", shard_name)
+            raise NotDrainedError()
+
+    def _is_shard_draining(self, shard_name: str) -> bool:
+        """Reports if a given shard is currently in the draining state.
+
+        Raises:
+            ConfigurationError, OperationFailure, ShardNotInClusterError,
+            ShardNotPlannedForRemovalError
+        """
+        sc_status = self.client.admin.command("listShards")
+        for shard in sc_status["shards"]:
+            if shard["_id"] == shard_name:
+                if "draining" not in shard:
+                    raise ShardNotPlannedForRemovalError(
+                        f"Shard {shard_name} has not been marked for removal",
+                    )
+                return shard["draining"]
+
+        raise ShardNotInClusterError(
+            f"Shard {shard_name} not in cluster, could not retrieve draining status"
+        )
+
+    def get_databases_for_shard(self, primary_shard) -> Optional[List[str]]:
+        """Returns a list of databases using the given shard as a primary shard.
+
+        In Sharded MongoDB clusters, mongos selects the primary shard when creating a new database
+        by picking the shard in the cluster that has the least amount of data. This means that:
+        1. There can be multiple primary shards in a cluster.
+        2. Until there is data written to the cluster there is effectively no primary shard.
+        """
+        databases_collection = self._get_databases_collection()
+        if databases_collection is None:
+            return
+
+        return databases_collection.distinct("_id", {"primary": primary_shard})
+
+    def _get_databases_collection(self) -> collection.Collection:
+        """Returns the databases collection if present.
+
+        The collection `databases` only gets created once data is written to the sharded cluster.
+        """
+        config_db = self.client["config"]
+        if "databases" not in config_db.list_collection_names():
+            logger.info("No data written to sharded cluster yet.")
+            return None
+
+        return config_db["databases"]
+
+    @staticmethod
+    def _is_any_draining(sc_status: Dict, ignore_shard: str = "") -> bool:
+        """Returns true if any shard members is draining.
+
+        Checks if any members in sharded cluster are draining data.
+
+        Args:
+            sc_status: current state of shard cluster status as reported by mongos.
+            ignore_shard: shard to ignore
+        """
+        return any(
+            # check draining status of all shards except the one to be ignored.
+            shard.get("draining", False) if shard["_id"] != ignore_shard else False
+            for shard in sc_status["shards"]
+        )
+
+    @staticmethod
+    def _hostname_from_hostport(hostname: str) -> str:
+        """Return hostname part from MongoDB returned.
+
+        mongos typically returns a value that contains both, hostname, hosts, and ports.
+        e.g. input: shard03/host7:27018,host8:27018,host9:27018
+        Return shard name
+        e.g. output: shard03
+        """
+        return hostname.split("/")[0]
+
+    def _log_removal_info(self, removal_info, shard_name):
+        """Logs removal information for a shard removal."""
+        remaining_chunks = self._retrieve_remaining_chunks(removal_info)
+        dbs_to_move = (
+            removal_info["dbsToMove"]
+            if "dbsToMove" in removal_info and removal_info["dbsToMove"] != []
+            else ["None"]
+        )
+        logger.info(
+            "Shard %s is draining status is: %s. Remaining chunks: %s. DBs to move: %s.",
+            shard_name,
+            removal_info["state"],
+            str(remaining_chunks),
+            ",".join(dbs_to_move),
+        )
+
+    @property
+    def is_ready(self) -> bool:
+        """Is mongos ready for services requests.
+
+        Returns:
+            True if services is ready False otherwise. Retries over a period of 60 seconds times to
+            allow server time to start up.
+
+        Raises:
+            ConfigurationError, ConfigurationError, OperationFailure
+        """
+        try:
+            for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
+                with attempt:
+                    # The ping command is cheap and does not require auth.
+                    self.client.admin.command("ping")
+        except RetryError:
+            return False
+
+        return True
+
+    def is_shard_aware(self, shard_name: str) -> bool:
+        """Returns True if provided shard is shard aware."""
+        sc_status = self.client.admin.command("listShards")
+        for shard in sc_status["shards"]:
+            if shard["_id"] == shard_name:
+                return shard["state"] == 1
+
+        return False
+
+    def _retrieve_remaining_chunks(self, removal_info) -> int:
+        """Parses the remaining chunks to remove from removeShard command."""
+        # when chunks have finished draining, remaining chunks is still in the removal info, but
+        # marked as 0. If "remaining" is not present, in removal_info then the shard is not yet
+        # draining
+        if "remaining" not in removal_info:
+            raise NotDrainedError()
+
+        return removal_info["remaining"]["chunks"] if "remaining" in removal_info else 0
+
+    def _move_primary(self, databases_to_move: List[str], old_primary: str) -> None:
+        """Moves all the provided databases to a new primary.
+
+        Raises:
+            NotEnoughSpaceError, ConfigurationError, OperationFailure
+        """
+        for database_name in databases_to_move:
+            db_size = self.get_db_size(database_name, old_primary)
+            new_shard, avail_space = self.get_shard_with_most_available_space(
+                shard_to_ignore=old_primary
+            )
+            if db_size > avail_space:
+                no_space_on_new_primary = (
+                    f"Cannot move primary for database: {database_name}, new shard: {new_shard}",
+                    f"does not have enough space. {db_size} > {avail_space}",
+                )
+                logger.error(no_space_on_new_primary)
+                raise NotEnoughSpaceError(no_space_on_new_primary)
+
+            # From MongoDB Docs: After starting movePrimary, do not perform any read or write
+            # operations against any unsharded collection in that database until the command
+            # completes.
+            logger.info(
+                "Moving primary on %s database to new primary: %s. Do NOT write to %s database.",
+                database_name,
+                new_shard,
+                database_name,
+            )
+            # This command does not return until MongoDB completes moving all data. This can take
+            # a long time.
+            self.client.admin.command("movePrimary", database_name, to=new_shard)
+            logger.info(
+                "Successfully moved primary on %s database to new primary: %s",
+                database_name,
+                new_shard,
+            )
+
+    def get_db_size(self, database_name, primary_shard) -> int:
+        """Returns the size of a DB on a given shard in bytes."""
+        database = self.client[database_name]
+        db_stats = database.command("dbStats")
+
+        # sharded databases are spread across multiple shards, find the amount of storage used on
+        # the primary shard
+        for shard_name, shard_storage_info in db_stats["raw"].items():
+            # shard names are of the format `shard-one/10.61.64.212:27017`
+            shard_name = shard_name.split("/")[0]
+            if shard_name != primary_shard:
+                continue
+
+            return shard_storage_info["storageSize"]
+
+        return 0
+
+    def get_shard_with_most_available_space(self, shard_to_ignore) -> Tuple[str, int]:
+        """Returns the shard in the cluster with the most available space and the space in bytes.
+
+        Algorithm used was similar to that used in mongo in `selectShardForNewDatabase`:
+        https://github.com/mongodb/mongo/blob/6/0/src/mongo/db/s/config/sharding_catalog_manager_database_operations.cpp#L68-L91
+        """
+        candidate_shard = None
+        candidate_free_space = -1
+        available_storage = self.client.admin.command("dbStats", freeStorage=1)
+
+        for shard_name, shard_storage_info in available_storage["raw"].items():
+            # shard names are of the format `shard-one/10.61.64.212:27017`
+            shard_name = shard_name.split("/")[0]
+            if shard_name == shard_to_ignore:
+                continue
+
+            current_free_space = shard_storage_info["freeStorageSize"]
+            if current_free_space > candidate_free_space:
+                candidate_shard = shard_name
+                candidate_free_space = current_free_space
+
+        return (candidate_shard, candidate_free_space)
+
+    def get_draining_shards(self) -> List[str]:
+        """Returns a list of the shards currently draining."""
+        sc_status = self.client.admin.command("listShards")
+        draining_shards = []
+        for shard in sc_status["shards"]:
+            if shard.get("draining", False):
+                draining_shards.append(shard["_id"])
+
+        return draining_shards

--- a/lib/charms/mongodb/v1/users.py
+++ b/lib/charms/mongodb/v1/users.py
@@ -1,0 +1,117 @@
+"""Users configuration for MongoDB."""
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+from typing import Set
+
+# The unique Charmhub library identifier, never change it
+LIBID = "b74007eda21c453a89e4dcc6382aa2b3"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 0
+
+
+class MongoDBUser:
+    """Base class for MongoDB users."""
+
+    _username = ""
+    _password_key_name = ""
+    _database_name = ""
+    _roles = []
+    _privileges = {}
+    _mongodb_role = ""
+    _hosts = []
+
+    def get_username(self) -> str:
+        """Returns the username of the user."""
+        return self._username
+
+    def get_password_key_name(self) -> str:
+        """Returns the key name for the password of the user."""
+        return self._password_key_name
+
+    def get_database_name(self) -> str:
+        """Returns the database of the user."""
+        return self._database_name
+
+    def get_roles(self) -> Set[str]:
+        """Returns the role of the user."""
+        return self._roles
+
+    def get_mongodb_role(self) -> str:
+        """Returns the MongoDB role of the user."""
+        return self._mongodb_role
+
+    def get_privileges(self) -> dict:
+        """Returns the privileges of the user."""
+        return self._privileges
+
+    def get_hosts(self) -> list:
+        """Returns the hosts of the user."""
+        return self._hosts
+
+    @staticmethod
+    def get_password_key_name_for_user(username: str) -> str:
+        """Returns the key name for the password of the user."""
+        if username == OperatorUser.get_username():
+            return OperatorUser.get_password_key_name()
+        elif username == MonitorUser.get_username():
+            return MonitorUser.get_password_key_name()
+        elif username == BackupUser.get_username():
+            return BackupUser.get_password_key_name()
+        else:
+            raise ValueError(f"Unknown user: {username}")
+
+
+class _OperatorUser(MongoDBUser):
+    """Operator user for MongoDB."""
+
+    _username = "operator"
+    _password_key_name = f"{_username}-password"
+    _database_name = "admin"
+    _roles = ["default"]
+    _hosts = []
+
+
+class _MonitorUser(MongoDBUser):
+    """Monitor user for MongoDB."""
+
+    _username = "monitor"
+    _password_key_name = f"{_username}-password"
+    _database_name = "admin"
+    _roles = ["monitor"]
+    _privileges = {
+        "resource": {"db": "", "collection": ""},
+        "actions": ["listIndexes", "listCollections", "dbStats", "dbHash", "collStats", "find"],
+    }
+    _mongodb_role = "explainRole"
+    _hosts = [
+        "127.0.0.1"
+    ]  # MongoDB Exporter can only connect to one replica - not the entire set.
+
+
+class _BackupUser(MongoDBUser):
+    """Backup user for MongoDB."""
+
+    _username = "backup"
+    _password_key_name = f"{_username}-password"
+    _database_name = ""
+    _roles = ["backup"]
+    _mongodb_role = "pbmAnyAction"
+    _privileges = {"resource": {"anyResource": True}, "actions": ["anyAction"]}
+    _hosts = ["127.0.0.1"]  # pbm cannot make a direct connection if multiple hosts are used
+
+
+OperatorUser = _OperatorUser()
+MonitorUser = _MonitorUser()
+BackupUser = _BackupUser()
+
+# List of system usernames needed for correct work on the charm.
+CHARM_USERS = [
+    OperatorUser.get_username(),
+    BackupUser.get_username(),
+    MonitorUser.get_username(),
+]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -23,3 +23,5 @@ requires:
   mongos_proxy:
     interface: mongodb_client
     scope: container
+  cluster:
+    interface: config-server

--- a/src/charm.py
+++ b/src/charm.py
@@ -3,16 +3,29 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 from typing import List
-from charms.mongodb.v1.helpers import copy_licenses_to_unit
+import os
+import pwd
+from charms.mongodb.v1.helpers import copy_licenses_to_unit, KEY_FILE
 from charms.operator_libs_linux.v1 import snap
+from pathlib import Path
+
+from charms.mongodb.v0.mongodb_secrets import SecretCache
+from typing import Set, List, Optional
+from exceptions import ApplicationHostNotFoundError
+from charms.mongodb.v0.mongodb_secrets import generate_secret_label
+from charms.mongodb.v1.mongos import MongosConfiguration
+from charms.mongodb.v0.mongodb import MongoDBConfiguration
+from charms.mongodb.v1.helpers import copy_licenses_to_unit
+from charms.mongodb.v0.config_server_interface import ClusterRequirer
+from charms.mongodb.v1.users import (
+    MongoDBUser,
+    OperatorUser,
+)
 
 from config import Config
 
 import ops
-from ops.model import (
-    BlockedStatus,
-    MaintenanceStatus,
-)
+from ops.model import BlockedStatus, MaintenanceStatus, Unit, Relation
 from ops.charm import (
     InstallEvent,
     StartEvent,
@@ -25,6 +38,8 @@ logger = logging.getLogger(__name__)
 
 APP_SCOPE = Config.Relations.APP_SCOPE
 UNIT_SCOPE = Config.Relations.UNIT_SCOPE
+ROOT_USER_GID = 0
+MONGO_USER = "snap_daemon"
 
 
 class MongosOperatorCharm(ops.CharmBase):
@@ -35,6 +50,8 @@ class MongosOperatorCharm(ops.CharmBase):
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.start, self._on_start)
 
+        self.cluster = ClusterRequirer(self)
+        self.secrets = SecretCache(self)
         # todo future PRs:
         # 1. start daemon when relation to config server is made
         # 2. add users for related application
@@ -84,11 +101,150 @@ class MongosOperatorCharm(ops.CharmBase):
 
             except snap.SnapError as e:
                 logger.error(
-                    "An exception occurred when installing %s. Reason: %s",
-                    snap_name,
-                    str(e),
+                    "An exception occurred when installing %s. Reason: %s", snap_name, str(e)
                 )
                 raise
+
+    @property
+    def mongos_config(self) -> MongoDBConfiguration:
+        """Generates a MongoDBConfiguration object for mongos in the deployment of MongoDB."""
+        return self._get_mongos_config_for_user(OperatorUser, set(self._unit_ips))
+
+    def _get_mongos_config_for_user(
+        self, user: MongoDBUser, hosts: Set[str], config_server_uri: str
+    ) -> MongosConfiguration:
+
+        return MongosConfiguration(
+            config_server_uri=config_server_uri,
+            database=user.get_database_name(),
+            username=user.get_username(),
+            password=self.get_secret(APP_SCOPE, user.get_password_key_name()),
+            hosts=hosts,
+            port=Config.MONGOS_PORT,
+            roles=user.get_roles(),
+            tls_external=None,  # Future PR will suport TLS
+            tls_internal=None,  # Future PR will suport TLS
+        )
+
+    def _unit_ip(self, unit: Unit) -> str:
+        """Returns the ip address of a given unit."""
+        # check if host is current host
+        if unit == self.unit:
+            return str(self.model.get_binding(Config.Relations.PEERS).network.bind_address)
+        # check if host is a peer
+        elif unit in self._peers.data:
+            return str(self._peers.data[unit].get("private-address"))
+        # raise exception if host not found
+        else:
+            raise ApplicationHostNotFoundError
+
+    @property
+    def _unit_ips(self) -> List[str]:
+        """Retrieve IP addresses associated with MongoDB application.
+
+        Returns:
+            a list of IP address associated with MongoDB application.
+        """
+        peer_addresses = []
+        if self._peers:
+            peer_addresses = [self._unit_ip(unit) for unit in self._peers.units]
+
+        self_address = self._unit_ip(self.unit)
+        addresses = []
+        if peer_addresses:
+            addresses.extend(peer_addresses)
+        addresses.append(self_address)
+        return addresses
+
+    @property
+    def _peers(self) -> Optional[Relation]:
+        """Fetch the peer relation.
+
+        Returns:
+             An `ops.model.Relation` object representing the peer relation.
+        """
+        return self.model.get_relation(Config.Relations.PEERS)
+
+    def get_secret(self, scope: str, key: str) -> Optional[str]:
+        """Get secret from the secret storage."""
+        label = generate_secret_label(self, scope)
+        secret = self.secrets.get(label)
+        if not secret:
+            return
+
+        value = secret.get_content().get(key)
+        if value != Config.Secrets.SECRET_DELETED_LABEL:
+            return value
+
+    def set_secret(self, scope: str, key: str, value: Optional[str]) -> Optional[str]:
+        """Set secret in the secret storage.
+
+        Juju versions > 3.0 use `juju secrets`, this function first checks
+          which secret store is being used before setting the secret.
+        """
+        if not value:
+            return self.remove_secret(scope, key)
+
+        label = generate_secret_label(self, scope)
+        secret = self.secrets.get(label)
+        if not secret:
+            self.secrets.add(label, {key: value}, scope)
+        else:
+            content = secret.get_content()
+            content.update({key: value})
+            secret.set_content(content)
+        return label
+
+    def remove_secret(self, scope, key) -> None:
+        """Removing a secret."""
+        label = generate_secret_label(self, scope)
+        secret = self.secrets.get(label)
+
+        if not secret:
+            return
+
+        content = secret.get_content()
+
+        if not content.get(key) or content[key] == Config.Secrets.SECRET_DELETED_LABEL:
+            logger.error(f"Non-existing secret {scope}:{key} was attempted to be removed.")
+            return
+
+        content[key] = Config.Secrets.SECRET_DELETED_LABEL
+        secret.set_content(content)
+
+    def get_keyfile_contents(self) -> str:
+        """Retrieves the contents of the keyfile on host machine."""
+        # wait for keyFile to be created by leader unit
+        if not self.get_secret(APP_SCOPE, Config.Secrets.SECRET_KEYFILE_NAME):
+            logger.debug("waiting for leader unit to generate keyfile contents")
+            return
+
+        key_file_path = f"{Config.MONGOD_CONF_DIR}/{KEY_FILE}"
+        key_file = Path(key_file_path)
+        if not key_file.is_file():
+            logger.info("no keyfile present")
+            return
+
+        with open(key_file_path, "r") as file:
+            key = file.read()
+
+        return key
+
+    def push_file_to_unit(self, parent_dir, file_name, file_contents) -> None:
+        """K8s charms can push files to their containers easily, this is a vm charm workaround."""
+        Path(parent_dir).mkdir(parents=True, exist_ok=True)
+        file_name = f"{parent_dir}/{file_name}"
+        with open(file_name, "w") as write_file:
+            write_file.write(file_contents)
+
+        # MongoDB limitation; it is needed 400 rights for keyfile and we need 440 rights on tls
+        # certs to be able to connect via MongoDB shell
+        if Config.TLS.KEY_FILE_NAME in file_name:
+            os.chmod(file_name, 0o400)
+        else:
+            os.chmod(file_name, 0o440)
+        mongodb_user = pwd.getpwnam(MONGO_USER)
+        os.chown(file_name, mongodb_user.pw_uid, ROOT_USER_GID)
 
     # END: helper functions
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,6 @@
 """Charm code for `mongos` daemon."""
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-from typing import List
 import os
 import pwd
 from charms.mongodb.v1.helpers import copy_licenses_to_unit, KEY_FILE
@@ -15,7 +14,6 @@ from exceptions import ApplicationHostNotFoundError
 from charms.mongodb.v0.mongodb_secrets import generate_secret_label
 from charms.mongodb.v1.mongos import MongosConfiguration
 from charms.mongodb.v0.mongodb import MongoDBConfiguration
-from charms.mongodb.v1.helpers import copy_licenses_to_unit
 from charms.mongodb.v0.config_server_interface import ClusterRequirer
 from charms.mongodb.v1.users import (
     MongoDBUser,
@@ -101,7 +99,9 @@ class MongosOperatorCharm(ops.CharmBase):
 
             except snap.SnapError as e:
                 logger.error(
-                    "An exception occurred when installing %s. Reason: %s", snap_name, str(e)
+                    "An exception occurred when installing %s. Reason: %s",
+                    snap_name,
+                    str(e),
                 )
                 raise
 
@@ -113,7 +113,6 @@ class MongosOperatorCharm(ops.CharmBase):
     def _get_mongos_config_for_user(
         self, user: MongoDBUser, hosts: Set[str], config_server_uri: str
     ) -> MongosConfiguration:
-
         return MongosConfiguration(
             config_server_uri=config_server_uri,
             database=user.get_database_name(),
@@ -122,15 +121,17 @@ class MongosOperatorCharm(ops.CharmBase):
             hosts=hosts,
             port=Config.MONGOS_PORT,
             roles=user.get_roles(),
-            tls_external=None,  # Future PR will suport TLS
-            tls_internal=None,  # Future PR will suport TLS
+            tls_external=None,  # Future PR will support TLS
+            tls_internal=None,  # Future PR will support TLS
         )
 
     def _unit_ip(self, unit: Unit) -> str:
         """Returns the ip address of a given unit."""
         # check if host is current host
         if unit == self.unit:
-            return str(self.model.get_binding(Config.Relations.PEERS).network.bind_address)
+            return str(
+                self.model.get_binding(Config.Relations.PEERS).network.bind_address
+            )
         # check if host is a peer
         elif unit in self._peers.data:
             return str(self._peers.data[unit].get("private-address"))
@@ -206,7 +207,9 @@ class MongosOperatorCharm(ops.CharmBase):
         content = secret.get_content()
 
         if not content.get(key) or content[key] == Config.Secrets.SECRET_DELETED_LABEL:
-            logger.error(f"Non-existing secret {scope}:{key} was attempted to be removed.")
+            logger.error(
+                f"Non-existing secret {scope}:{key} was attempted to be removed."
+            )
             return
 
         content[key] = Config.Secrets.SECRET_DELETED_LABEL
@@ -221,6 +224,7 @@ class MongosOperatorCharm(ops.CharmBase):
 
         key_file_path = f"{Config.MONGOD_CONF_DIR}/{KEY_FILE}"
         key_file = Path(key_file_path)
+        print(key_file.is_file())
         if not key_file.is_file():
             logger.info("no keyfile present")
             return

--- a/src/config.py
+++ b/src/config.py
@@ -24,7 +24,24 @@ class Config:
         APP_SCOPE = "app"
         UNIT_SCOPE = "unit"
         PEERS = "router-peers"
+        CLUSTER_RELATIONS_NAME = "cluster"
         Scopes = Literal[APP_SCOPE, UNIT_SCOPE]
+
+    class TLS:
+        """TLS related config for MongoDB Charm."""
+
+        EXT_PEM_FILE = "external-cert.pem"
+        EXT_CA_FILE = "external-ca.crt"
+        INT_PEM_FILE = "internal-cert.pem"
+        INT_CA_FILE = "internal-ca.crt"
+        KEY_FILE_NAME = "keyFile"
+        TLS_PEER_RELATION = "certificates"
+
+        SECRET_CA_LABEL = "ca-secret"
+        SECRET_KEY_LABEL = "key-secret"
+        SECRET_CERT_LABEL = "cert-secret"
+        SECRET_CSR_LABEL = "csr-secret"
+        SECRET_CHAIN_LABEL = "chain-secret"
 
     class Secrets:
         """Secrets related constants."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,6 +4,12 @@
 import unittest
 from unittest.mock import patch
 
+
+import pytest
+import re
+from parameterized import parameterized
+from unittest import mock
+
 from charms.operator_libs_linux.v1 import snap
 from ops.model import BlockedStatus
 from ops.testing import Harness
@@ -20,6 +26,10 @@ class TestCharm(unittest.TestCase):
         self.harness.begin()
         self.peer_rel_id = self.harness.add_relation("router-peers", "router-peers")
 
+    @pytest.fixture
+    def use_caplog(self, caplog):
+        self._caplog = caplog
+
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.snap.SnapCache")
     @patch("subprocess.check_call")
@@ -28,3 +38,45 @@ class TestCharm(unittest.TestCase):
         snap_cache.side_effect = snap.SnapError
         self.harness.charm.on.install.emit()
         self.assertTrue(isinstance(self.harness.charm.unit.status, BlockedStatus))
+
+    @parameterized.expand([("app"), ("unit")])
+    def test_set_secret_returning_secret_id(self, scope):
+        secret_id = self.harness.charm.set_secret(scope, "somekey", "bla")
+        assert re.match(f"mongos.{scope}", secret_id)
+
+    @parameterized.expand([("app"), ("unit")])
+    def test_set_reset_new_secret(self, scope):
+        """NOTE: currently ops.testing seems to allow for non-leader to set secrets too!"""
+        # Getting current password
+        self.harness.charm.set_secret(scope, "new-secret", "bla")
+        assert self.harness.charm.get_secret(scope, "new-secret") == "bla"
+
+        # Reset new secret
+        self.harness.charm.set_secret(scope, "new-secret", "blablabla")
+        assert self.harness.charm.get_secret(scope, "new-secret") == "blablabla"
+
+        # Set another new secret
+        self.harness.charm.set_secret(scope, "new-secret2", "blablabla")
+        assert self.harness.charm.get_secret(scope, "new-secret2") == "blablabla"
+
+    @parameterized.expand([("app"), ("unit")])
+    def test_invalid_secret(self, scope):
+        with self.assertRaises(TypeError):
+            self.harness.charm.set_secret("unit", "somekey", 1)
+
+        self.harness.charm.set_secret("unit", "somekey", "")
+        assert self.harness.charm.get_secret(scope, "somekey") is None
+
+    @patch("charm.MongosOperatorCharm.get_secret", return_value=None)
+    def test_get_keyfile_contents_no_secret(self, get_secret):
+        """Tests file isn't checked if secret isn't set."""
+        self.assertEqual(self.harness.charm.get_keyfile_contents(), None)
+
+    @patch("charm.MongosOperatorCharm.get_secret", return_value="keyfile-contents")
+    @patch("charm.Path")
+    def test_get_keyfile_contents_no_keyfile(self, path, get_secret):
+        """Tests file isn't checked if file doesn't exists."""
+        path_function = mock.Mock()
+        path_function.is_file.return_value = False
+        path.return_value = path_function
+        self.assertEqual(self.harness.charm.get_keyfile_contents(), None)

--- a/tests/unit/test_config_server_lib.py
+++ b/tests/unit/test_config_server_lib.py
@@ -1,0 +1,66 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+import unittest
+from unittest.mock import patch
+
+from ops.testing import Harness
+
+from charm import MongosOperatorCharm
+
+from .helpers import patch_network_get
+
+
+PEER_ADDR = {"private-address": "127.4.5.6"}
+KEYFILE = {"key-file": "key-file-contents"}
+
+
+class TestConfigServerInterface(unittest.TestCase):
+    @patch_network_get(private_address="1.1.1.1")
+    def setUp(self):
+        self.harness = Harness(MongosOperatorCharm)
+        self.harness.begin()
+        self.harness.add_relation("router-peers", "router-peers")
+        self.harness.set_leader(True)
+        self.charm = self.harness.charm
+        self.addCleanup(self.harness.cleanup)
+
+    @patch("ops.framework.EventBase.defer")
+    @patch("charm.ClusterRequirer.update_keyfile")
+    def test_on_relation_changed_waits_keyfile(self, update_keyfile, defer):
+        """Tests that relation changed waits for keyfile."""
+
+        # fails due to being run on non-config-server
+        relation_id = self.harness.add_relation("cluster", "config-server")
+        self.harness.add_relation_unit(relation_id, "config-server/0")
+        self.harness.update_relation_data(relation_id, "config-server/0", PEER_ADDR)
+        update_keyfile.assert_not_called()
+        defer.assert_called()
+
+    @patch("charm.MongosOperatorCharm.push_file_to_unit")
+    @patch("charm.MongosOperatorCharm.get_keyfile_contents")
+    @patch("charm.MongosOperatorCharm.set_secret")
+    def test_same_keyfile(self, set_secret, get_keyfile_contents, push_file_to_unit):
+        """Tests that charm doesn't update keyfile when they are the same."""
+        get_keyfile_contents.return_value = KEYFILE["key-file"]
+        relation_id = self.harness.add_relation("cluster", "config-server")
+        self.harness.add_relation_unit(relation_id, "config-server/0")
+        self.harness.update_relation_data(relation_id, "config-server", KEYFILE)
+
+        push_file_to_unit.assert_not_called()
+        set_secret.assert_not_called()
+
+    @patch("charm.MongosOperatorCharm.push_file_to_unit")
+    @patch("charm.MongosOperatorCharm.get_keyfile_contents")
+    @patch("charm.MongosOperatorCharm.set_secret")
+    def test_non_leader_doesnt_set_keyfile_secret(
+        self, set_secret, get_keyfile_contents, push_file_to_unit
+    ):
+        """Tests that non leaders dont set keyfile secret."""
+        self.harness.set_leader(False)
+
+        relation_id = self.harness.add_relation("cluster", "config-server")
+        self.harness.add_relation_unit(relation_id, "config-server/0")
+        self.harness.update_relation_data(relation_id, "config-server", KEYFILE)
+
+        push_file_to_unit.assert_called()
+        set_secret.assert_not_called()


### PR DESCRIPTION
## Issue
DPE-2992 is to start the mongos subordinate charm with the provided config server. In order for the config server and for mongos to be connected they both must have the same keyfile

## Solution
Recieve the keyfile

## Follow up PRs
2. Updating the library to actually start the mongos service with the information of the config server
3. Integration tests

## Testing
```
juju deploy ./*charm --config role="config-server"
juju deploy application
juju deploy mongos
juju integrate application mongos
juju integrate mongos:cluster mongodb:cluster
juju ssh mongos
sudo cat KEY_FILE_PATH
```