### PR TITLE
update build with cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,6 @@ jobs:
 
   build:
     name: Build charms
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v5.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v6
     permissions:
       actions: write # Needed to manage GitHub Actions cache


### PR DESCRIPTION
Current build workflow is `v5.0.1`, instead use `v6` which has [an update](https://github.com/canonical/data-platform-workflows/pull/109#pullrequestreview-1757667889) to fix our build step