### PR TITLE
[DPE-3381] - charm correctly reports status

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+  annotations: false

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 *.py[cod]
 .idea
 .vscode/
+coverage.xml


### PR DESCRIPTION
## Issue
After removing an integration from `mongos` and `config-server` mongos charm **does not** show that it is blocked waiting for config server

## Solution 
Implement update status hook and add tests verifying behaviour