### PR TITLE
[DPE-4664] hotfix to support Juju secrets on 3.1.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,4 +75,4 @@ jobs:
     with:
       artifact-name: ${{ needs.build.outputs.artifact-name }}
       cloud: lxd
-      juju-agent-version: 3.1.6
+      juju-agent-version: 3.1.7

--- a/lib/charms/mongodb/v0/mongodb_secrets.py
+++ b/lib/charms/mongodb/v0/mongodb_secrets.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional
 
 from ops import Secret, SecretInfo
 from ops.charm import CharmBase
-from ops.model import SecretNotFoundError
+from ops.model import ModelError, SecretNotFoundError
 
 from config import Config
 from exceptions import SecretAlreadyExistsError
@@ -93,7 +93,21 @@ class CachedSecret:
         """Getting cached secret content."""
         if not self._secret_content:
             if self.meta:
-                self._secret_content = self.meta.get_content()
+                try:
+                    self._secret_content = self.meta.get_content(refresh=True)
+                except (ValueError, ModelError) as err:
+                    # https://bugs.launchpad.net/juju/+bug/2042596
+                    # Only triggered when 'refresh' is set
+                    known_model_errors = [
+                        "ERROR either URI or label should be used for getting an owned secret but not both",
+                        "ERROR secret owner cannot use --refresh",
+                    ]
+                    if isinstance(err, ModelError) and not any(
+                        msg in str(err) for msg in known_model_errors
+                    ):
+                        raise
+                    # Due to: ValueError: Secret owner cannot use refresh=True
+                    self._secret_content = self.meta.get_content()
         return self._secret_content
 
     def set_content(self, content: Dict[str, str]) -> None:


### PR DESCRIPTION
## Issue
Juju secrets updates in 3.1.7 break mongos charm resulting in infinite secret changed / removed events

## Solution
Apply a hotfix to support 3.1.7

In the future we should adopt something [like this long term solution](https://github.com/canonical/mongodb-operator/pull/333) 