### PR TITLE
[DPE-4757]  - Update shared libs so that charm supports blocking operations during upgrade

### DIFF
--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -42,7 +42,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 14
 
 
 class ClusterProvider(Object):
@@ -109,8 +109,10 @@ class ClusterProvider(Object):
         """Handles providing mongos with KeyFile and hosts."""
         if not self.pass_hook_checks(event):
             if not self.is_valid_mongos_integration():
-                self.charm.unit.status = BlockedStatus(
-                    "Relation to mongos not supported, config role must be config-server"
+                self.charm.status.set_and_share_status(
+                    BlockedStatus(
+                        "Relation to mongos not supported, config role must be config-server"
+                    )
                 )
             logger.info("Skipping relation joined event: hook checks did not pass")
             return
@@ -238,6 +240,13 @@ class ClusterRequirer(Object):
         )
 
     def _on_database_created(self, event) -> None:
+        if self.charm.upgrade_in_progress:
+            logger.warning(
+                "Processing client applications is not supported during an upgrade. The charm may be in a broken, unrecoverable state."
+            )
+            event.defer()
+            return
+
         if not self.charm.unit.is_leader():
             return
 
@@ -259,7 +268,9 @@ class ClusterRequirer(Object):
             event.relation.id, CONFIG_SERVER_DB_KEY
         )
         if not key_file_contents or not config_server_db_uri:
-            self.charm.unit.status = WaitingStatus("Waiting for secrets from config-server")
+            self.charm.status.set_and_share_status(
+                WaitingStatus("Waiting for secrets from config-server")
+            )
             return
 
         updated_keyfile = self.update_keyfile(key_file_contents=key_file_contents)
@@ -271,17 +282,18 @@ class ClusterRequirer(Object):
 
         # mongos is not available until it is using new secrets
         logger.info("Restarting mongos with new secrets")
-        self.charm.unit.status = MaintenanceStatus("starting mongos")
+        self.charm.status.set_and_share_status(MaintenanceStatus("starting mongos"))
         self.charm.restart_charm_services()
 
         # restart on high loaded databases can be very slow (e.g. up to 10-20 minutes).
         if not self.is_mongos_running():
             logger.info("mongos has not started, deferring")
-            self.charm.unit.status = WaitingStatus("Waiting for mongos to start")
+            self.charm.status.set_and_share_status(WaitingStatus("Waiting for mongos to start"))
             event.defer()
             return
 
-        self.charm.unit.status = ActiveStatus()
+        self.charm.status.set_and_share_status(ActiveStatus())
+        self.charm.mongos_intialised = True
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         # Only relation_deparated events can check if scaling down
@@ -332,6 +344,13 @@ class ClusterRequirer(Object):
                 str(type(event)),
             )
 
+            event.defer()
+            return False
+
+        if self.charm.upgrade_in_progress:
+            logger.warning(
+                "Processing client applications is not supported during an upgrade. The charm may be in a broken, unrecoverable state."
+            )
             event.defer()
             return False
 

--- a/lib/charms/mongodb/v0/mongodb_tls.py
+++ b/lib/charms/mongodb/v0/mongodb_tls.py
@@ -38,7 +38,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 logger = logging.getLogger(__name__)
 
@@ -174,10 +174,10 @@ class MongoDBTLS(Object):
             self.charm.config_server.update_ca_secret(new_ca=None)
 
         logger.info("Restarting mongod with TLS disabled.")
-        self.charm.unit.status = MaintenanceStatus("disabling TLS")
+        self.charm.status.set_and_share_status(MaintenanceStatus("disabling TLS"))
         self.charm.delete_tls_certificate_from_workload()
         self.charm.restart_charm_services()
-        self.charm.unit.status = ActiveStatus()
+        self.charm.status.set_and_share_status(ActiveStatus())
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Enable TLS when TLS certificate available."""
@@ -224,16 +224,16 @@ class MongoDBTLS(Object):
 
         self.charm.delete_tls_certificate_from_workload()
         self.charm.push_tls_certificate_to_workload()
-        self.charm.unit.status = MaintenanceStatus("enabling TLS")
+        self.charm.status.set_and_share_status(MaintenanceStatus("enabling TLS"))
         self.charm.restart_charm_services()
 
         if not self.charm.is_db_service_ready():
-            self.charm.unit.status = WaitingStatus("Waiting for MongoDB to start")
+            self.charm.status.set_and_share_status(WaitingStatus("Waiting for MongoDB to start"))
         elif self.charm.unit.status == WaitingStatus(
             "Waiting for MongoDB to start"
         ) or self.charm.unit.status == MaintenanceStatus("enabling TLS"):
             # clear waiting status if db service is ready
-            self.charm.unit.status = ActiveStatus()
+            self.charm.status.set_and_share_status(ActiveStatus())
 
     def waiting_for_certs(self):
         """Returns a boolean indicating whether additional certs are needed."""

--- a/lib/charms/mongos/v0/set_status.py
+++ b/lib/charms/mongos/v0/set_status.py
@@ -1,23 +1,13 @@
-"""TODO: Add a proper docstring here.
+#!/usr/bin/env python3
+"""Code for handing statuses in the app and unit."""
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import json
 
-This is a placeholder docstring for this charm library. Docstrings are
-presented on Charmhub and updated whenever you push a new version of the
-library.
+from ops.charm import CharmBase
+from ops.framework import Object
+from ops.model import StatusBase
 
-Complete documentation about creating and documenting libraries can be found
-in the SDK docs at https://juju.is/docs/sdk/libraries.
-
-See `charmcraft publish-lib` and `charmcraft fetch-lib` for details of how to
-share and consume charm libraries. They serve to enhance collaboration
-between charmers. Use a charmer's libraries for classes that handle
-integration with their charm.
-
-Bear in mind that new revisions of the different major API versions (v0, v1,
-v2 etc) are maintained independently.  You can continue to update v0 and v1
-after you have pushed v3.
-
-Markdown is supported, following the CommonMark specification.
-"""
 
 # The unique Charmhub library identifier, never change it
 LIBID = "0713372afa0841359edbb777273ecdbf"
@@ -29,4 +19,35 @@ LIBAPI = 0
 # to 0 if you are raising the major API version
 LIBPATCH = 1
 
-# TODO: add your code here! Happy coding!
+
+class MongosStatusHandler(Object):
+    """Verifies versions across multiple integrated applications."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+    ) -> None:
+        """Constructor for CrossAppVersionChecker.
+
+        Args:
+            charm: charm to inherit from.
+        """
+        super().__init__(charm, None)
+        self.charm = charm
+
+        # TODO Future Feature/Epic: handle update_status
+
+    # BEGIN Helpers
+
+    def set_and_share_status(self, status: StatusBase):
+        """Sets the charm status and shares it where applicable."""
+        # TODO Future Feature/Epic: process other statuses, i.e. only set provided status if its
+        # appropriate.
+        self.charm.unit.status = status
+
+        self.set_app_status()
+
+    def set_app_status(self):
+        """TODO Future Feature/Epic: parse statuses and set a status for the entire app."""
+
+    # END: Helpers

--- a/lib/charms/mongos/v0/set_status.py
+++ b/lib/charms/mongos/v0/set_status.py
@@ -2,7 +2,6 @@
 """Code for handing statuses in the app and unit."""
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-import json
 
 from ops.charm import CharmBase
 from ops.framework import Object

--- a/lib/charms/mongos/v0/set_status.py
+++ b/lib/charms/mongos/v0/set_status.py
@@ -1,0 +1,32 @@
+"""TODO: Add a proper docstring here.
+
+This is a placeholder docstring for this charm library. Docstrings are
+presented on Charmhub and updated whenever you push a new version of the
+library.
+
+Complete documentation about creating and documenting libraries can be found
+in the SDK docs at https://juju.is/docs/sdk/libraries.
+
+See `charmcraft publish-lib` and `charmcraft fetch-lib` for details of how to
+share and consume charm libraries. They serve to enhance collaboration
+between charmers. Use a charmer's libraries for classes that handle
+integration with their charm.
+
+Bear in mind that new revisions of the different major API versions (v0, v1,
+v2 etc) are maintained independently.  You can continue to update v0 and v1
+after you have pushed v3.
+
+Markdown is supported, following the CommonMark specification.
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "0713372afa0841359edbb777273ecdbf"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+# TODO: add your code here! Happy coding!

--- a/src/charm.py
+++ b/src/charm.py
@@ -104,7 +104,9 @@ class MongosOperatorCharm(ops.CharmBase):
         # start hooks are fired before relation hooks and `mongos` requires a config-server in
         # order to start. Wait to receive config-server info from the relation event before
         # starting `mongos` daemon
-        self.status.set_and_share_status(BlockedStatus("Missing relation to config-server."))
+        self.status.set_and_share_status(
+            BlockedStatus("Missing relation to config-server.")
+        )
 
     def _on_update_status(self, _):
         """Handle the update status event"""
@@ -115,7 +117,9 @@ class MongosOperatorCharm(ops.CharmBase):
             logger.info(
                 "Missing integration to config-server. mongos cannot run unless connected to config-server."
             )
-            self.status.set_and_share_status(BlockedStatus("Missing relation to config-server."))
+            self.status.set_and_share_status(
+                BlockedStatus("Missing relation to config-server.")
+            )
             return
 
         if self.cluster.get_tls_statuses():
@@ -125,7 +129,9 @@ class MongosOperatorCharm(ops.CharmBase):
         # restart on high loaded databases can be very slow (e.g. up to 10-20 minutes).
         if not self.cluster.is_mongos_running():
             logger.info("mongos has not started yet")
-            self.status.set_and_share_status(WaitingStatus("Waiting for mongos to start."))
+            self.status.set_and_share_status(
+                WaitingStatus("Waiting for mongos to start.")
+            )
             return
 
         self.status.set_and_share_status(ActiveStatus())
@@ -212,7 +218,9 @@ class MongosOperatorCharm(ops.CharmBase):
         content = secret.get_content()
 
         if not content.get(key) or content[key] == Config.Secrets.SECRET_DELETED_LABEL:
-            logger.error(f"Non-existing secret {scope}:{key} was attempted to be removed.")
+            logger.error(
+                f"Non-existing secret {scope}:{key} was attempted to be removed."
+            )
             return
 
         content[key] = Config.Secrets.SECRET_DELETED_LABEL
@@ -313,7 +321,9 @@ class MongosOperatorCharm(ops.CharmBase):
             return
 
         # a mongos shard can only be related to one config server
-        config_server_rel = self.model.relations[Config.Relations.CLUSTER_RELATIONS_NAME][0]
+        config_server_rel = self.model.relations[
+            Config.Relations.CLUSTER_RELATIONS_NAME
+        ][0]
         self.cluster.database_requires.update_relation_data(
             config_server_rel.id, {USER_ROLES_TAG: roles_str}
         )
@@ -326,14 +336,18 @@ class MongosOperatorCharm(ops.CharmBase):
             return
 
         # a mongos shard can only be related to one config server
-        config_server_rel = self.model.relations[Config.Relations.CLUSTER_RELATIONS_NAME][0]
+        config_server_rel = self.model.relations[
+            Config.Relations.CLUSTER_RELATIONS_NAME
+        ][0]
         self.cluster.database_requires.update_relation_data(
             config_server_rel.id, {DATABASE_TAG: database}
         )
 
     def set_external_connectivity(self, external_connectivity: bool) -> None:
         """Sets the connectivity type for mongos."""
-        self.app_peer_data[EXTERNAL_CONNECTIVITY_TAG] = json.dumps(external_connectivity)
+        self.app_peer_data[EXTERNAL_CONNECTIVITY_TAG] = json.dumps(
+            external_connectivity
+        )
 
     def check_relation_broken_or_scale_down(self, event: RelationDepartedEvent) -> None:
         """Checks relation departed event is the result of removed relation or scale down.
@@ -471,6 +485,19 @@ class MongosOperatorCharm(ops.CharmBase):
         """Returns True if the underlying database service is ready."""
         with MongosConnection(self.mongos_config) as mongos:
             return mongos.is_ready
+
+    @property
+    def mongos_initialised(self) -> bool:
+        """Check if mongos is initialised."""
+        return "mongos_initialised" in self.app_peer_data
+
+    @mongos_initialised.setter
+    def mongos_initialised(self, value: bool):
+        """Set the mongos_initialised flag."""
+        if value:
+            self.app_peer_data["mongos_initialised"] = str(value)
+        elif "mongos_initialised" in self.app_peer_data:
+            del self.app_peer_data["mongos_initialised"]
 
     # END: helper functions
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,9 +21,12 @@ from pathlib import Path
 from typing import Set, List, Optional, Dict
 from upgrades.mongos_upgrade import MongosUpgrade
 
+
+from charms.mongos.v0.mongos_client_interface import MongosProvider
+from charms.mongos.v0.set_status import MongosStatusHandler
+
 from charms.mongodb.v0.mongodb_secrets import SecretCache
 from charms.mongodb.v0.mongodb_tls import MongoDBTLS
-from charms.mongos.v0.mongos_client_interface import MongosProvider
 from charms.mongodb.v0.mongodb_secrets import generate_secret_label
 from charms.mongodb.v1.mongos import MongosConfiguration, MongosConnection
 from charms.mongodb.v0.config_server_interface import ClusterRequirer
@@ -79,17 +82,18 @@ class MongosOperatorCharm(ops.CharmBase):
         self.tls = MongoDBTLS(self, Config.Relations.PEERS, substrate=Config.SUBSTRATE)
         self.mongos_provider = MongosProvider(self)
         self.upgrade = MongosUpgrade(self)
+        self.status = MongosStatusHandler(self)
 
     # BEGIN: hook functions
     def _on_install(self, event: InstallEvent) -> None:
         """Handle the install event (fired on startup)."""
-        self.unit.status = MaintenanceStatus("installing mongos")
+        self.status.set_and_share_status(MaintenanceStatus("installing mongos"))
         try:
             self.install_snap_packages(packages=Config.SNAP_PACKAGES)
 
         except snap.SnapError as e:
             logger.info("Failed to install snap, error: %s", e)
-            self.unit.status = BlockedStatus("couldn't install mongos")
+            self.status.set_and_share_status(BlockedStatus("couldn't install mongos"))
             return
 
         # add licenses
@@ -100,7 +104,7 @@ class MongosOperatorCharm(ops.CharmBase):
         # start hooks are fired before relation hooks and `mongos` requires a config-server in
         # order to start. Wait to receive config-server info from the relation event before
         # starting `mongos` daemon
-        self.unit.status = BlockedStatus("Missing relation to config-server.")
+        self.status.set_and_share_status(BlockedStatus("Missing relation to config-server."))
 
     def _on_update_status(self, _):
         """Handle the update status event"""
@@ -111,20 +115,20 @@ class MongosOperatorCharm(ops.CharmBase):
             logger.info(
                 "Missing integration to config-server. mongos cannot run unless connected to config-server."
             )
-            self.unit.status = BlockedStatus("Missing relation to config-server.")
+            self.status.set_and_share_status(BlockedStatus("Missing relation to config-server."))
             return
 
         if self.cluster.get_tls_statuses():
-            self.unit.status = self.cluster.get_tls_statuses()
+            self.status.set_and_share_status(self.cluster.get_tls_statuses())
             return
 
         # restart on high loaded databases can be very slow (e.g. up to 10-20 minutes).
         if not self.cluster.is_mongos_running():
             logger.info("mongos has not started yet")
-            self.unit.status = WaitingStatus("Waiting for mongos to start.")
+            self.status.set_and_share_status(WaitingStatus("Waiting for mongos to start."))
             return
 
-        self.unit.status = ActiveStatus()
+        self.status.set_and_share_status(ActiveStatus())
 
     # END: hook functions
 
@@ -208,9 +212,7 @@ class MongosOperatorCharm(ops.CharmBase):
         content = secret.get_content()
 
         if not content.get(key) or content[key] == Config.Secrets.SECRET_DELETED_LABEL:
-            logger.error(
-                f"Non-existing secret {scope}:{key} was attempted to be removed."
-            )
+            logger.error(f"Non-existing secret {scope}:{key} was attempted to be removed.")
             return
 
         content[key] = Config.Secrets.SECRET_DELETED_LABEL
@@ -311,9 +313,7 @@ class MongosOperatorCharm(ops.CharmBase):
             return
 
         # a mongos shard can only be related to one config server
-        config_server_rel = self.model.relations[
-            Config.Relations.CLUSTER_RELATIONS_NAME
-        ][0]
+        config_server_rel = self.model.relations[Config.Relations.CLUSTER_RELATIONS_NAME][0]
         self.cluster.database_requires.update_relation_data(
             config_server_rel.id, {USER_ROLES_TAG: roles_str}
         )
@@ -326,18 +326,14 @@ class MongosOperatorCharm(ops.CharmBase):
             return
 
         # a mongos shard can only be related to one config server
-        config_server_rel = self.model.relations[
-            Config.Relations.CLUSTER_RELATIONS_NAME
-        ][0]
+        config_server_rel = self.model.relations[Config.Relations.CLUSTER_RELATIONS_NAME][0]
         self.cluster.database_requires.update_relation_data(
             config_server_rel.id, {DATABASE_TAG: database}
         )
 
     def set_external_connectivity(self, external_connectivity: bool) -> None:
         """Sets the connectivity type for mongos."""
-        self.app_peer_data[EXTERNAL_CONNECTIVITY_TAG] = json.dumps(
-            external_connectivity
-        )
+        self.app_peer_data[EXTERNAL_CONNECTIVITY_TAG] = json.dumps(external_connectivity)
 
     def check_relation_broken_or_scale_down(self, event: RelationDepartedEvent) -> None:
         """Checks relation departed event is the result of removed relation or scale down.

--- a/src/upgrades/mongos_upgrade.py
+++ b/src/upgrades/mongos_upgrade.py
@@ -63,7 +63,9 @@ class MongosUpgrade(Object):
         )
         self.framework.observe(charm.on.upgrade_charm, self._on_upgrade_charm)
 
-        self.framework.observe(charm.on["force-upgrade"].action, self._on_force_upgrade_action)
+        self.framework.observe(
+            charm.on["force-upgrade"].action, self._on_force_upgrade_action
+        )
         self.framework.observe(self.post_upgrade_event, self.run_post_upgrade_check)
 
     # BEGIN: Event handlers
@@ -135,7 +137,7 @@ class MongosUpgrade(Object):
         """Runs post-upgrade checks for after mongos router upgrade."""
         # The mongos service cannot be considered ready until it has a config-server. Therefore
         # it is not necessary to do any sophisticated checks.
-        if not self.charm.config_server_db:
+        if not self.charm.mongos_intialised:
             self._upgrade.unit_state = upgrade.UnitState.HEALTHY
             return
 
@@ -148,7 +150,9 @@ class MongosUpgrade(Object):
         """Runs post-upgrade checks for after a shard/config-server/replset/cluster upgrade."""
         logger.debug("-----\nchecking mongos running\n----")
         if not self.charm.cluster.is_mongos_running():
-            logger.debug("Waiting for mongos router to be ready before finalising upgrade.")
+            logger.debug(
+                "Waiting for mongos router to be ready before finalising upgrade."
+            )
             event.defer()
             return
 
@@ -188,8 +192,12 @@ class MongosUpgrade(Object):
     def get_random_write_and_collection(self) -> Tuple[str, str]:
         """Returns a tuple for a random collection name and a unique write to add to it."""
         choices = string.ascii_letters + string.digits
-        collection_name = "collection_" + "".join([secrets.choice(choices) for _ in range(32)])
-        write_value = "unique_write_" + "".join([secrets.choice(choices) for _ in range(16)])
+        collection_name = "collection_" + "".join(
+            [secrets.choice(choices) for _ in range(32)]
+        )
+        write_value = "unique_write_" + "".join(
+            [secrets.choice(choices) for _ in range(16)]
+        )
         return (collection_name, write_value)
 
     def add_write_to_sharded_cluster(self, collection_name, write_value) -> None:

--- a/src/upgrades/mongos_upgrade.py
+++ b/src/upgrades/mongos_upgrade.py
@@ -63,9 +63,7 @@ class MongosUpgrade(Object):
         )
         self.framework.observe(charm.on.upgrade_charm, self._on_upgrade_charm)
 
-        self.framework.observe(
-            charm.on["force-upgrade"].action, self._on_force_upgrade_action
-        )
+        self.framework.observe(charm.on["force-upgrade"].action, self._on_force_upgrade_action)
         self.framework.observe(self.post_upgrade_event, self.run_post_upgrade_check)
 
     # BEGIN: Event handlers
@@ -96,7 +94,7 @@ class MongosUpgrade(Object):
                 authorized = self._upgrade.authorized
             except upgrade.PrecheckFailed as exception:
                 self._set_upgrade_status()
-                self.charm.unit.status = exception.status
+                self.charm.status.set_and_share_status(exception.status)
                 logger.debug(f"Set unit status to {self.unit.status}")
                 logger.error(exception.status.message)
                 return
@@ -150,9 +148,7 @@ class MongosUpgrade(Object):
         """Runs post-upgrade checks for after a shard/config-server/replset/cluster upgrade."""
         logger.debug("-----\nchecking mongos running\n----")
         if not self.charm.cluster.is_mongos_running():
-            logger.debug(
-                "Waiting for mongos router to be ready before finalising upgrade."
-            )
+            logger.debug("Waiting for mongos router to be ready before finalising upgrade.")
             event.defer()
             return
 
@@ -160,12 +156,12 @@ class MongosUpgrade(Object):
         if not self.is_mongos_able_to_read_write():
             logger.error("mongos is not able to read/write after upgrade.")
             logger.info(ROLLBACK_INSTRUCTIONS)
-            self.charm.unit.status = Config.Status.UNHEALTHY_UPGRADE
+            self.charm.status.set_and_share_status(Config.Status.UNHEALTHY_UPGRADE)
             event.defer()
             return
 
         if self.charm.unit.status == Config.Status.UNHEALTHY_UPGRADE:
-            self.charm.unit.status = ActiveStatus()
+            self.charm.status.set_and_share_status(ActiveStatus())
 
         logger.debug("upgrade of unit succeeded.")
         self._upgrade.unit_state = upgrade.UnitState.HEALTHY
@@ -192,12 +188,8 @@ class MongosUpgrade(Object):
     def get_random_write_and_collection(self) -> Tuple[str, str]:
         """Returns a tuple for a random collection name and a unique write to add to it."""
         choices = string.ascii_letters + string.digits
-        collection_name = "collection_" + "".join(
-            [secrets.choice(choices) for _ in range(32)]
-        )
-        write_value = "unique_write_" + "".join(
-            [secrets.choice(choices) for _ in range(16)]
-        )
+        collection_name = "collection_" + "".join([secrets.choice(choices) for _ in range(32)])
+        write_value = "unique_write_" + "".join([secrets.choice(choices) for _ in range(16)])
         return (collection_name, write_value)
 
     def add_write_to_sharded_cluster(self, collection_name, write_value) -> None:
@@ -249,7 +241,7 @@ class MongosUpgrade(Object):
                 "Rollback with `juju refresh`. Pre-upgrade check failed:"
             )
         ):
-            self.charm.unit.status = (
+            self.charm.status.set_and_share_status(
                 self._upgrade.get_unit_juju_status() or ActiveStatus()
             )
 

--- a/src/upgrades/upgrade.py
+++ b/src/upgrades/upgrade.py
@@ -266,7 +266,7 @@ class Upgrade(abc.ABC):
         See https://chat.canonical.com/canonical/pl/cmf6uhm1rp8b7k8gkjkdsj4mya
         """
         # Until the mongos charm has a config-server there is nothing to check. Allow an upgrade.
-        if not self.charm.config_server_db:
+        if not self.charm.mongos_intialised:
             return
 
         if not self.is_mongos_able_to_read_write():


### PR DESCRIPTION
## Issue
When Mongos charm is upgrading some operations are feasible, which should be deferred

## Solution
1.Pull in changes from mongodb charm so that certain operations are blocked on upgrade
2. Update charm so that updated libs don't break the charm
