### PR TITLE
[DPE-5643] - add nightly 3.6 runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,6 @@ jobs:
     name: Lint
     uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v21.0.0
 
-
   lib-check:
     name: Check libraries
     runs-on: ubuntu-latest
@@ -67,7 +66,17 @@ jobs:
       cache: true
 
   integration-test:
-    name: Integration test charm | 3.5.3
+    strategy:
+      fail-fast: false
+      matrix:
+        juju:
+          # This runs on all runs
+          - agent: 3.5.3 # renovate: juju-agent-pin-minor
+            allure_report: true
+          # This runs only on scheduled runs, DPW 21 specifics (scheduled + 3.6/X)
+          - snap_channel: 3.6/beta
+            allure_report: false
+    name: Integration test charm | ${{ matrix.juju.agent || matrix.juju.snap_channel }}
     needs:
       - lint
       - unit-test
@@ -76,7 +85,8 @@ jobs:
     with:
       artifact-prefix: packed-charm-cache-true
       cloud: lxd
-      juju-agent-version: 3.5.3 # renovate: juju-agent-pin-minor
-      _beta_allure_report: true
+      juju-agent-version: ${{ matrix.juju.agent }}
+      juju-snap-channel: ${{ matrix.juju.snap_channel }}
+      _beta_allure_report: ${{ matrix.juju.allure_report }}
     permissions:
       contents: write


### PR DESCRIPTION
## Issue
We want to support 3.6 runs but do not know what issues there might be

## Solution
Add nightly runs for 3.6 so we can track what changes for 3.6 might be needed