### PR TITLE
[DPE-6192] fix TLS tests that flakely fails on CA mismatch

### DIFF
--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -98,9 +98,18 @@ async def test_tls_reenabled(ops_test: OpsTest) -> None:
 async def test_mongos_tls_ca_mismatch(ops_test: OpsTest) -> None:
     """Tests that mongos charm can disable TLS."""
     await toggle_tls_mongos(ops_test, enable=False)
+
     await ops_test.model.deploy(
         CERTS_APP_NAME, application_name=DIFFERENT_CERTS_APP_NAME, channel="edge"
     )
+
+    await ops_test.model.wait_for_idle(
+        apps=[MONGOS_APP_NAME],
+        idle_period=60,
+        timeout=TIMEOUT,
+        raise_on_blocked=False,
+    )
+
     await ops_test.model.wait_for_idle(
         apps=[DIFFERENT_CERTS_APP_NAME],
         idle_period=20,
@@ -246,12 +255,12 @@ async def rotate_and_verify_certs(ops_test: OpsTest) -> None:
     for unit in ops_test.model.applications[MONGOS_APP_NAME].units:
         original_tls_info[unit.name] = {}
 
-        original_tls_info[unit.name]["external_cert_contents"] = (
-            await get_file_contents(ops_test, unit, EXTERNAL_CERT_PATH)
-        )
-        original_tls_info[unit.name]["internal_cert_contents"] = (
-            await get_file_contents(ops_test, unit, INTERNAL_CERT_PATH)
-        )
+        original_tls_info[unit.name][
+            "external_cert_contents"
+        ] = await get_file_contents(ops_test, unit, EXTERNAL_CERT_PATH)
+        original_tls_info[unit.name][
+            "internal_cert_contents"
+        ] = await get_file_contents(ops_test, unit, INTERNAL_CERT_PATH)
         original_tls_info[unit.name]["external_cert_time"] = await time_file_created(
             ops_test, unit.name, EXTERNAL_CERT_PATH
         )


### PR DESCRIPTION
## Issue
test for mismatch in CA fails occasionally

## Solution
test is trying to do too many concurrent ops, ensure a wait between ops

## Testing
tested by hand several times + reran CI 3x times to ensure green pipeline