### PR TITLE
[DPE-6355] - robust tls race conds

### DIFF
--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -53,7 +53,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 1
 
 
 class ClusterProvider(Object):
@@ -104,15 +104,6 @@ class ClusterProvider(Object):
                 "Skipping %s. ClusterProvider is only be executed by config-server",
                 type(event),
             )
-            return False
-
-        # race condition where mongos cannot start without TLS certificates, but mongos cannot
-        # request TLS certificates without knowing the name of the config-server.
-        if self.is_waiting_to_request_certs():
-            logger.info(
-                "Mongos was waiting for config-server to enable TLS. Wait for TLS to be enabled until starting mongos."
-            )
-            event.defer()
             return False
 
         if self.charm.upgrade_in_progress:
@@ -333,7 +324,7 @@ class ClusterRequirer(Object):
             self.charm.share_connection_info()
 
     def _on_relation_changed(self, event) -> None:
-        """Starts/restarts mongos with config server information."""
+        """Starts/restarts monogs with config server information."""
         if not self.pass_hook_checks(event):
             logger.info("pre-hook checks did not pass, not executing event")
             return
@@ -463,6 +454,15 @@ class ClusterRequirer(Object):
             logger.info(
                 "Deferring %s. mongos uses TLS, but config-server does not. Please synchronise encryption methods.",
                 str(type(event)),
+            )
+            event.defer()
+            return False
+
+        # race condition where mongos cannot start without TLS certificates, but mongos cannot
+        # request TLS certificates without knowing the name of the config-server.
+        if self.is_waiting_to_request_certs():
+            logger.info(
+                "Mongos was waiting for config-server to enable TLS. Wait for TLS to be enabled until starting mongos."
             )
             event.defer()
             return False

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -14,8 +14,15 @@ from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseRequestedEvent,
     DatabaseRequires,
 )
+from charms.mongodb.v0.mongo import MongoConnection
 from charms.mongodb.v1.mongos import MongosConnection
-from ops.charm import CharmBase, EventBase, RelationBrokenEvent, RelationChangedEvent
+from ops.charm import (
+    CharmBase,
+    EventBase,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+)
 from ops.framework import Object
 from ops.model import (
     ActiveStatus,
@@ -24,6 +31,7 @@ from ops.model import (
     StatusBase,
     WaitingStatus,
 )
+from pymongo.errors import PyMongoError
 
 from config import Config
 
@@ -45,7 +53,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 15
 
 
 class ClusterProvider(Object):
@@ -55,8 +63,10 @@ class ClusterProvider(Object):
         self,
         charm: CharmBase,
         relation_name: str = Config.Relations.CLUSTER_RELATIONS_NAME,
+        substrate: str = Config.Substrate.VM,
     ) -> None:
         """Constructor for ShardingProvider object."""
+        self.substrate = substrate
         self.relation_name = relation_name
         self.charm = charm
         self.database_provides = DatabaseProvides(
@@ -195,7 +205,9 @@ class ClusterProvider(Object):
             )
             return
 
-        self.charm.client_relations.oversee_users(departed_relation_id, event)
+        # mongos-k8s router is in charge of removing its own users.
+        if self.substrate == Config.Substrate.VM:
+            self.charm.client_relations.oversee_users(departed_relation_id, event)
 
     def update_config_server_db(self, event):
         """Provides related mongos applications with new config server db."""
@@ -264,7 +276,7 @@ class ClusterRequirer(Object):
         super().__init__(charm, self.relation_name)
         self.framework.observe(
             charm.on[self.relation_name].relation_created,
-            self.database_requires._on_relation_created_event,
+            self._on_relation_created_handler,
         )
 
         self.framework.observe(
@@ -280,6 +292,13 @@ class ClusterRequirer(Object):
         self.framework.observe(
             charm.on[self.relation_name].relation_broken, self._on_relation_broken
         )
+
+    def _on_relation_created_handler(self, event: RelationCreatedEvent) -> None:
+        logger.info("Integrating to config-server")
+        self.charm.status.set_and_share_status(
+            WaitingStatus("Connecting to config-server")
+        )
+        self.database_requires._on_relation_created_event(event)
 
     def _on_database_created(self, event) -> None:
         if self.charm.upgrade_in_progress:
@@ -329,6 +348,8 @@ class ClusterRequirer(Object):
 
         # avoid restarting mongos when possible
         if not updated_keyfile and not updated_config and self.is_mongos_running():
+            # mongos-k8s router must update its users on start
+            self._update_k8s_users(event)
             return
 
         # mongos is not available until it is using new secrets
@@ -349,6 +370,22 @@ class ClusterRequirer(Object):
         if self.charm.unit.is_leader():
             self.charm.mongos_initialised = True
 
+        # mongos-k8s router must update its users on start
+        self._update_k8s_users(event)
+
+    def _update_k8s_users(self, event) -> None:
+        if self.substrate != Config.Substrate.K8S:
+            return
+
+        # K8s can handle its 1:Many users after being initialized
+        try:
+            self.charm.client_relations.oversee_users(None, None)
+        except PyMongoError:
+            event.defer()
+            logger.debug(
+                "failed to add users on mongos-k8s router, will defer and try again."
+            )
+
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         # Only relation_deparated events can check if scaling down
         if not self.charm.has_departed_run(event.relation.id):
@@ -362,6 +399,13 @@ class ClusterRequirer(Object):
             logger.info(
                 "Skipping relation broken event, broken event due to scale down"
             )
+            return
+
+        try:
+            self.handle_mongos_k8s_users_removal()
+        except PyMongoError:
+            logger.debug("Trouble removing router users, will defer and try again")
+            event.defer()
             return
 
         self.charm.stop_mongos_service()
@@ -378,9 +422,24 @@ class ClusterRequirer(Object):
         if self.substrate == Config.Substrate.VM:
             self.charm.remove_connection_info()
         else:
-            self.db_initialised = False
+            self.charm.db_initialised = False
 
     # BEGIN: helper functions
+    def handle_mongos_k8s_users_removal(self) -> None:
+        """Handles the removal of all client mongos-k8s users and the mongos-k8s admin user.
+
+        Raises:
+            PyMongoError
+        """
+        if not self.charm.unit.is_leader() or self.substrate != Config.Substrate.K8S:
+            return
+
+        self.charm.client_relations.remove_all_relational_users()
+
+        # now that the client mongos users have been removed we can remove ourself
+        with MongoConnection(self.charm.mongo_config) as mongo:
+            mongo.drop_user(self.charm.mongo_config.username)
+
     def pass_hook_checks(self, event):
         """Runs the pre-hooks checks for ClusterRequirer, returns True if all pass."""
         if self.is_mongos_tls_missing():
@@ -396,15 +455,6 @@ class ClusterRequirer(Object):
                 "Deferring %s. mongos uses TLS, but config-server does not. Please synchronise encryption methods.",
                 str(type(event)),
             )
-            event.defer()
-            return False
-
-        if not self.is_ca_compatible():
-            logger.info(
-                "Deferring %s. mongos is integrated to a different CA than the config server. Please use the same CA for all cluster components.",
-                str(type(event)),
-            )
-
             event.defer()
             return False
 

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -91,6 +91,9 @@ class ClusterProvider(Object):
 
     def pass_hook_checks(self, event: EventBase) -> bool:
         """Runs the pre-hooks checks for ClusterProvider, returns True if all pass."""
+        if not self.charm.unit.is_leader():
+            return False
+
         if not self.charm.db_initialised:
             logger.info("Deferring %s. db is not initialised.", type(event))
             event.defer()
@@ -103,7 +106,13 @@ class ClusterProvider(Object):
             )
             return False
 
-        if not self.charm.unit.is_leader():
+        # race condition where mongos cannot start without TLS certificates, but mongos cannot
+        # request TLS certificates without knowing the name of the config-server.
+        if self.is_waiting_to_request_certs():
+            logger.info(
+                "Mongos was waiting for config-server to enable TLS. Wait for TLS to be enabled until starting mongos."
+            )
+            event.defer()
             return False
 
         if self.charm.upgrade_in_progress:
@@ -324,7 +333,7 @@ class ClusterRequirer(Object):
             self.charm.share_connection_info()
 
     def _on_relation_changed(self, event) -> None:
-        """Starts/restarts monogs with config server information."""
+        """Starts/restarts mongos with config server information."""
         if not self.pass_hook_checks(event):
             logger.info("pre-hook checks did not pass, not executing event")
             return
@@ -542,6 +551,22 @@ class ClusterRequirer(Object):
             self.model.get_relation(Config.Relations.CLUSTER_RELATIONS_NAME).id,
             CONFIG_SERVER_DB_KEY,
         )
+
+    def is_waiting_to_request_certs(self) -> bool:
+        """Returns True if mongos has been waiting for config server in order to request certs."""
+        if not self.charm.model.get_relation(Config.TLS.TLS_PEER_RELATION):
+            return False
+
+        mongos_tls_ca = self.charm.tls.get_tls_secret(
+            internal=True, label_name=Config.TLS.SECRET_CA_LABEL
+        )
+
+        # our CA is none until certs have been requested. We cannot request certs until integrated
+        # to config-server.
+        if not mongos_tls_ca:
+            return True
+
+        return False
 
     def is_ca_compatible(self) -> bool:
         """Returns true if both the mongos and the config server use the same CA."""

--- a/lib/charms/mongodb/v1/mongodb_tls.py
+++ b/lib/charms/mongodb/v1/mongodb_tls.py
@@ -70,8 +70,12 @@ class MongoDBTLS(Object):
             self.charm.on[Config.TLS.TLS_PEER_RELATION].relation_broken,
             self._on_tls_relation_broken,
         )
-        self.framework.observe(self.certs.on.certificate_available, self._on_certificate_available)
-        self.framework.observe(self.certs.on.certificate_expiring, self._on_certificate_expiring)
+        self.framework.observe(
+            self.certs.on.certificate_available, self._on_certificate_available
+        )
+        self.framework.observe(
+            self.certs.on.certificate_expiring, self._on_certificate_expiring
+        )
 
     def is_tls_enabled(self, internal: bool):
         """Returns a boolean indicating if TLS for a given internal/external is enabled."""
@@ -80,7 +84,10 @@ class MongoDBTLS(Object):
     def _on_set_tls_private_key(self, event: ActionEvent) -> None:
         """Set the TLS private key, which will be used for requesting the certificate."""
         logger.debug("Request to set TLS private key received.")
-        if self.charm.is_role(Config.Role.MONGOS) and not self.charm.has_config_server():
+        if (
+            self.charm.is_role(Config.Role.MONGOS)
+            and not self.charm.has_config_server()
+        ):
             logger.error(
                 "mongos is not running (not integrated to config-server) deferring renewal of certificates."
             )
@@ -93,8 +100,12 @@ class MongoDBTLS(Object):
             return
 
         try:
-            self.request_certificate(event.params.get("external-key", None), internal=False)
-            self.request_certificate(event.params.get("internal-key", None), internal=True)
+            self.request_certificate(
+                event.params.get("external-key", None), internal=False
+            )
+            self.request_certificate(
+                event.params.get("internal-key", None), internal=True
+            )
             logger.debug("Successfully set TLS private key.")
         except ValueError as e:
             event.fail(str(e))
@@ -145,7 +156,10 @@ class MongoDBTLS(Object):
 
     def _on_tls_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Request certificate when TLS relation joined."""
-        if self.charm.is_role(Config.Role.MONGOS) and not self.charm.has_config_server():
+        if (
+            self.charm.is_role(Config.Role.MONGOS)
+            and not self.charm.has_config_server()
+        ):
             logger.info(
                 "mongos is not running (not integrated to config-server) deferring renewal of certificates."
             )
@@ -174,7 +188,9 @@ class MongoDBTLS(Object):
                 "Disabling TLS is not supported during an upgrade. The charm may be in a broken, unrecoverable state."
             )
 
-        logger.debug("Disabling external and internal TLS for unit: %s", self.charm.unit.name)
+        logger.debug(
+            "Disabling external and internal TLS for unit: %s", self.charm.unit.name
+        )
 
         for internal in [True, False]:
             self.set_tls_secret(internal, Config.TLS.SECRET_CA_LABEL, None)
@@ -200,13 +216,18 @@ class MongoDBTLS(Object):
             event.defer()
             return
 
-        if not self.charm.db_initialised:
+        # mongos must recieve its certificates in order for it to get initialised
+        if not self.charm.db_initialised and not self.charm.is_role(Config.Role.MONGOS):
             logger.info("Deferring %s. db is not initialised.", str(type(event)))
             event.defer()
             return
 
-        int_csr = self.get_tls_secret(internal=True, label_name=Config.TLS.SECRET_CSR_LABEL)
-        ext_csr = self.get_tls_secret(internal=False, label_name=Config.TLS.SECRET_CSR_LABEL)
+        int_csr = self.get_tls_secret(
+            internal=True, label_name=Config.TLS.SECRET_CSR_LABEL
+        )
+        ext_csr = self.get_tls_secret(
+            internal=False, label_name=Config.TLS.SECRET_CSR_LABEL
+        )
 
         if ext_csr and event.certificate_signing_request.rstrip() == ext_csr.rstrip():
             logger.debug("The external TLS certificate available.")
@@ -238,15 +259,24 @@ class MongoDBTLS(Object):
             event.defer()
             return
 
-        logger.info("Restarting mongod with TLS enabled.")
-
         self.charm.delete_tls_certificate_from_workload()
         self.charm.push_tls_certificate_to_workload()
+
+        if not self.charm.db_initialised and self.charm.is_role(Config.Role.MONGOS):
+            logger.info(
+                "Deferring TLS restart until the mongos charm is connected to config-server."
+            )
+            event.defer()
+            return
+
+        logger.info("Restarting mongod with TLS enabled.")
         self.charm.status.set_and_share_status(MaintenanceStatus("enabling TLS"))
         self.charm.restart_charm_services()
 
         if not self.charm.is_db_service_ready():
-            self.charm.status.set_and_share_status(WaitingStatus("Waiting for MongoDB to start"))
+            self.charm.status.set_and_share_status(
+                WaitingStatus("Waiting for MongoDB to start")
+            )
         elif self.charm.unit.status == WaitingStatus(
             "Waiting for MongoDB to start"
         ) or self.charm.unit.status == MaintenanceStatus("enabling TLS"):
@@ -255,10 +285,14 @@ class MongoDBTLS(Object):
 
     def is_waiting_for_both_certs(self) -> bool:
         """Returns a boolean indicating whether additional certs are needed."""
-        if not self.get_tls_secret(internal=True, label_name=Config.TLS.SECRET_CERT_LABEL):
+        if not self.get_tls_secret(
+            internal=True, label_name=Config.TLS.SECRET_CERT_LABEL
+        ):
             logger.debug("Waiting for internal certificate.")
             return True
-        if not self.get_tls_secret(internal=False, label_name=Config.TLS.SECRET_CERT_LABEL):
+        if not self.get_tls_secret(
+            internal=False, label_name=Config.TLS.SECRET_CERT_LABEL
+        ):
             logger.debug("Waiting for external certificate.")
             return True
 
@@ -266,7 +300,10 @@ class MongoDBTLS(Object):
 
     def _on_certificate_expiring(self, event: CertificateExpiringEvent) -> None:
         """Request the new certificate when old certificate is expiring."""
-        if self.charm.is_role(Config.Role.MONGOS) and not self.charm.has_config_server():
+        if (
+            self.charm.is_role(Config.Role.MONGOS)
+            and not self.charm.has_config_server()
+        ):
             logger.info(
                 "mongos is not running (not integrated to config-server) deferring renewal of certificates."
             )
@@ -283,7 +320,9 @@ class MongoDBTLS(Object):
             internal = False
         elif (
             event.certificate.rstrip()
-            == self.get_tls_secret(internal=True, label_name=Config.TLS.SECRET_CERT_LABEL).rstrip()
+            == self.get_tls_secret(
+                internal=True, label_name=Config.TLS.SECRET_CERT_LABEL
+            ).rstrip()
         ):
             logger.debug("The internal TLS certificate expiring.")
             internal = True
@@ -297,7 +336,9 @@ class MongoDBTLS(Object):
     def request_new_certificates(self, internal: bool) -> None:
         """Requests the renewel of a new certificate."""
         key = self.get_tls_secret(internal, Config.TLS.SECRET_KEY_LABEL).encode("utf-8")
-        old_csr = self.get_tls_secret(internal, Config.TLS.SECRET_CSR_LABEL).encode("utf-8")
+        old_csr = self.get_tls_secret(internal, Config.TLS.SECRET_CSR_LABEL).encode(
+            "utf-8"
+        )
         sans = self.get_new_sans()
         new_csr = generate_csr(
             private_key=key,
@@ -313,7 +354,9 @@ class MongoDBTLS(Object):
             new_certificate_signing_request=new_csr,
         )
 
-        self.set_tls_secret(internal, Config.TLS.SECRET_CSR_LABEL, new_csr.decode("utf-8"))
+        self.set_tls_secret(
+            internal, Config.TLS.SECRET_CSR_LABEL, new_csr.decode("utf-8")
+        )
         self.set_waiting_for_cert_to_update(waiting=True, internal=internal)
 
     def get_new_sans(self) -> dict[str, list[str]]:
@@ -332,7 +375,11 @@ class MongoDBTLS(Object):
                 f"{self.charm.app.name}-{unit_id}.{self.charm.app.name}-endpoints",
             ],
             SANS_IPS_KEY: [
-                str(self.charm.model.get_binding(self.peer_relation).network.bind_address)
+                str(
+                    self.charm.model.get_binding(
+                        self.peer_relation
+                    ).network.bind_address
+                )
             ],
         }
 
@@ -353,7 +400,9 @@ class MongoDBTLS(Object):
 
         try:
             cert = x509.load_pem_x509_certificate(pem_file.encode(), default_backend())
-            sans = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+            sans = cert.extensions.get_extension_for_class(
+                x509.SubjectAlternativeName
+            ).value
             sans_ip = [str(san) for san in sans.get_values_for_type(x509.IPAddress)]
             sans_dns = [str(san) for san in sans.get_values_for_type(x509.DNSName)]
         except x509.ExtensionNotFound:

--- a/lib/charms/mongodb/v1/mongodb_tls.py
+++ b/lib/charms/mongodb/v1/mongodb_tls.py
@@ -156,6 +156,16 @@ class MongoDBTLS(Object):
 
     def _on_tls_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Request certificate when TLS relation joined."""
+        if (
+            self.charm.is_role(Config.Role.MONGOS)
+            and not self.charm.has_config_server()
+        ):
+            logger.info(
+                "mongos is not running (not integrated to config-server) deferring renewal of certificates."
+            )
+            event.defer()
+            return
+
         if self.charm.upgrade_in_progress:
             logger.warning(
                 "Enabling TLS is not supported during an upgrade. The charm may be in a broken, unrecoverable state."
@@ -199,6 +209,16 @@ class MongoDBTLS(Object):
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Enable TLS when TLS certificate available."""
+        if (
+            self.charm.is_role(Config.Role.MONGOS)
+            and not self.charm.has_config_server()
+        ):
+            logger.debug(
+                "mongos requires config-server in order to start, do not restart with TLS until integrated to config-server"
+            )
+            event.defer()
+            return
+
         # mongos must recieve its certificates in order for it to get initialised
         if not self.charm.db_initialised and not self.charm.is_role(Config.Role.MONGOS):
             logger.info("Deferring %s. db is not initialised.", str(type(event)))
@@ -245,11 +265,12 @@ class MongoDBTLS(Object):
         self.charm.delete_tls_certificate_from_workload()
         self.charm.push_tls_certificate_to_workload()
 
+        # if mongos hasn't been started let it be started with the integration to the
+        # config-server
         if not self.charm.db_initialised and self.charm.is_role(Config.Role.MONGOS):
             logger.info(
-                "Deferring TLS restart until the mongos charm is connected to config-server."
+                "Mongos has not yet been initialized, will enable TLS when it is set up with the config-server."
             )
-            event.defer()
             return
 
         logger.info("Restarting mongod with TLS enabled.")

--- a/lib/charms/mongodb/v1/mongodb_tls.py
+++ b/lib/charms/mongodb/v1/mongodb_tls.py
@@ -156,16 +156,6 @@ class MongoDBTLS(Object):
 
     def _on_tls_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Request certificate when TLS relation joined."""
-        if (
-            self.charm.is_role(Config.Role.MONGOS)
-            and not self.charm.has_config_server()
-        ):
-            logger.info(
-                "mongos is not running (not integrated to config-server) deferring renewal of certificates."
-            )
-            event.defer()
-            return
-
         if self.charm.upgrade_in_progress:
             logger.warning(
                 "Enabling TLS is not supported during an upgrade. The charm may be in a broken, unrecoverable state."
@@ -209,13 +199,6 @@ class MongoDBTLS(Object):
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Enable TLS when TLS certificate available."""
-        if self.charm.is_role(Config.Role.MONGOS) and not self.charm.config_server_db:
-            logger.debug(
-                "mongos requires config-server in order to start, do not restart with TLS until integrated to config-server"
-            )
-            event.defer()
-            return
-
         # mongos must recieve its certificates in order for it to get initialised
         if not self.charm.db_initialised and not self.charm.is_role(Config.Role.MONGOS):
             logger.info("Deferring %s. db is not initialised.", str(type(event)))

--- a/src/charm.py
+++ b/src/charm.py
@@ -560,6 +560,12 @@ class MongosOperatorCharm(ops.CharmBase):
             self.unit_host(self.unit)
         ]
 
+    def get_ext_mongos_host(self, unit, incl_port=False) -> str:  # TODO incl_port
+        if not self.is_external_client:
+            return None
+
+        return self.unit_host(unit)
+
     @property
     def is_external_client(self) -> Optional[str]:
         """Returns the database requested by the hosting application of the subordinate charm."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -560,11 +560,17 @@ class MongosOperatorCharm(ops.CharmBase):
             self.unit_host(self.unit)
         ]
 
-    def get_ext_mongos_host(self, unit, incl_port=False) -> str:  # TODO incl_port
+    def get_ext_mongos_host(
+        self, unit, incl_port=False
+    ) -> Optional[str]:  # TODO incl_port
+        """Returns the external host for the given unit."""
         if not self.is_external_client:
             return None
 
-        return self.unit_host(unit)
+        if not incl_port:
+            return self.unit_host(unit)
+        else:
+            return f"{self.unit_host(unit)}:{Config.MONGOS_PORT}"
 
     @property
     def is_external_client(self) -> Optional[str]:

--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -178,7 +178,7 @@ async def deploy_cluster(ops_test: OpsTest) -> None:
     await wait_for_mongos_units_blocked(ops_test, MONGOS_APP_NAME, timeout=TIMEOUT)
 
 
-async def build_cluster(ops_test: OpsTest) -> None:
+async def build_cluster(ops_test: OpsTest, integrate_with_mongos=True) -> None:
     """Connects the cluster components to each other."""
     # prepare sharded cluster
     await ops_test.model.wait_for_idle(
@@ -198,13 +198,17 @@ async def build_cluster(ops_test: OpsTest) -> None:
         timeout=TIMEOUT,
     )
 
-    # connect sharded cluster to mongos
-    await ops_test.model.integrate(
-        f"{MONGOS_APP_NAME}:{CLUSTER_REL_NAME}",
-        f"{CONFIG_SERVER_APP_NAME}:{CLUSTER_REL_NAME}",
-    )
+    apps = [CONFIG_SERVER_APP_NAME, SHARD_APP_NAME]
+    if integrate_with_mongos:
+        # connect sharded cluster to mongos
+        await ops_test.model.integrate(
+            f"{MONGOS_APP_NAME}:{CLUSTER_REL_NAME}",
+            f"{CONFIG_SERVER_APP_NAME}:{CLUSTER_REL_NAME}",
+        )
+        apps.append(MONGOS_APP_NAME)
+
     await ops_test.model.wait_for_idle(
-        apps=[CONFIG_SERVER_APP_NAME, SHARD_APP_NAME, MONGOS_APP_NAME],
+        apps=apps,
         idle_period=20,
         status="active",
         timeout=TIMEOUT,
@@ -216,7 +220,7 @@ async def deploy_tls(ops_test: OpsTest) -> None:
     await ops_test.model.deploy(CERTS_APP_NAME, channel="edge")
 
     await ops_test.model.wait_for_idle(
-        apps=[CERTS_APP_NAME, CONFIG_SERVER_APP_NAME],
+        apps=[CERTS_APP_NAME],
         idle_period=20,
         raise_on_blocked=False,
         timeout=TIMEOUT,
@@ -255,12 +259,12 @@ async def rotate_and_verify_certs(ops_test: OpsTest) -> None:
     for unit in ops_test.model.applications[MONGOS_APP_NAME].units:
         original_tls_info[unit.name] = {}
 
-        original_tls_info[unit.name][
-            "external_cert_contents"
-        ] = await get_file_contents(ops_test, unit, EXTERNAL_CERT_PATH)
-        original_tls_info[unit.name][
-            "internal_cert_contents"
-        ] = await get_file_contents(ops_test, unit, INTERNAL_CERT_PATH)
+        original_tls_info[unit.name]["external_cert_contents"] = (
+            await get_file_contents(ops_test, unit, EXTERNAL_CERT_PATH)
+        )
+        original_tls_info[unit.name]["internal_cert_contents"] = (
+            await get_file_contents(ops_test, unit, INTERNAL_CERT_PATH)
+        )
         original_tls_info[unit.name]["external_cert_time"] = await time_file_created(
             ops_test, unit.name, EXTERNAL_CERT_PATH
         )

--- a/tests/integration/tls_tests/test_tls_race_conds.py
+++ b/tests/integration/tls_tests/test_tls_race_conds.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+import pytest
+from pytest_operator.plugin import OpsTest
+from .helpers import (
+    check_mongos_tls_enabled,
+)
+from .test_tls import (
+    deploy_cluster,
+    deploy_tls,
+    build_cluster,
+    integrate_cluster_with_tls,
+    integrate_mongos_with_tls,
+)
+
+MONGOS_SERVICE = "snap.charmed-mongodb.mongos.service"
+APPLICATION_APP_NAME = "application"
+MONGOS_APP_NAME = "mongos"
+MONGODB_CHARM_NAME = "mongodb"
+CONFIG_SERVER_APP_NAME = "config-server"
+SHARD_APP_NAME = "shard"
+CLUSTER_COMPONENTS = [CONFIG_SERVER_APP_NAME, SHARD_APP_NAME]
+CERT_REL_NAME = "certificates"
+SHARD_REL_NAME = "sharding"
+CLUSTER_REL_NAME = "cluster"
+CONFIG_SERVER_REL_NAME = "config-server"
+CERTS_APP_NAME = "self-signed-certificates"
+DIFFERENT_CERTS_APP_NAME = "self-signed-certificates-separate"
+TIMEOUT = 15 * 60
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest) -> None:
+    """Build and deploy a sharded cluster."""
+    await deploy_cluster(ops_test)
+    await build_cluster(ops_test, integrate_with_mongos=False)
+    await deploy_tls(ops_test)
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_mongos_tls_enabled(ops_test: OpsTest) -> None:
+    """Tests race condition: mongos charm can integrate with TLS and then the config-server."""
+    await integrate_cluster_with_tls(ops_test)
+    await integrate_mongos_with_tls(ops_test)
+
+    # integrate mongos with config-server
+    await ops_test.model.integrate(
+        f"{MONGOS_APP_NAME}:{CLUSTER_REL_NAME}",
+        f"{CONFIG_SERVER_APP_NAME}:{CLUSTER_REL_NAME}",
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[MONGOS_APP_NAME],
+        idle_period=20,
+        status="active",
+        timeout=TIMEOUT,
+    )
+
+    await check_mongos_tls_enabled(ops_test)


### PR DESCRIPTION
## Issue
This solves #87 

The issue was that a race condition was occuring and the charm went into a blocked state when trying to enable TLS and mongos at the same time.

## Solution

1. Do not request a certificate until we have a config server since a configs-server is needed for the subject name in the cert
2. Update the relation event for cluster relation to wait until the sans are correct and the cert is requested, then add the router 
