### PR TITLE
[DPE-6543] add TICS workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  labels:
+    - self-hosted
+    - linux
+    - amd64
+    - tiobe
+    - jammy

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -1,0 +1,45 @@
+name: TICS run self-hosted test (github-action)
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  push: # TODO FIXME - remove this before pushing
+
+jobs:
+  build:
+    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
+
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y python3.10-venv
+
+      - name: Install pipx
+        run: python3 -m pip install --user pipx && python3 -m pipx ensurepath
+
+      - name: Add pipx to PATH
+        run: echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Install tox and poetry using pipx
+        run: |
+          pipx install tox
+          pipx install poetry
+
+      - name: Run tox tests to create coverage.xml
+        run: tox run -e unit
+
+      - name: move results to necessary folder for TICS
+        run: |
+          mkdir .cover
+          mv coverage.xml .cover/coverage.xml
+
+      - name: Run TICS analysis with github-action
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: mongodb-operator
+          branchdir: .
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -2,7 +2,6 @@ name: TICS run self-hosted test (github-action)
 
 on:
   workflow_dispatch: # Allows manual triggering
-  push: # TODO FIXME - remove this before pushing
 
 jobs:
   build:

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -38,7 +38,7 @@ jobs:
         uses: tiobe/tics-github-action@v3
         with:
           mode: qserver
-          project: mongodb-operator
+          project: mongos-operator
           branchdir: .
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}


### PR DESCRIPTION
## Issue
We need the ability to run TIOBE workflow on the charm

## Solution
Add the workflow to our charm. [Based on the example provided by TIOBE](https://github.com/canonical/ticsimg/blob/main/.github/workflows/tics_run_sh_ghaction_test.yml_)

We leverage the Canonical org level secret for TICSAUTHTOKEN for this workflow as specified by the TIOBE instructions. 