### PR TITLE
Schedule TICS

### DIFF
--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -1,6 +1,8 @@
 name: TICS run self-hosted test (github-action)
 
 on:
+  schedule:
+    - cron: "0 2 * * 6" # Every Saturday 2:00 AM UTC
   workflow_dispatch: # Allows manual triggering
 
 jobs:


### PR DESCRIPTION
This pull request introduces a scheduled trigger to the GitHub Actions workflow for running self-hosted tests. 

* [`.github/workflows/tics_run_sh_ghaction_test.yml`](diffhunk://#diff-594936f70c4be3041fe643be75996fd4d5d1c50675521239e0d7811b85790b90R4-R5): Added a cron schedule to run the workflow every Saturday at 2:00 AM UTC.