### PR TITLE
patch: bump mongo-single-kernel-library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1375,14 +1375,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.2"
+version = "1.8.3"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration", "unit"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.2-py3-none-any.whl", hash = "sha256:a2394de0744e5d785143380bf6d815e85a8065c55c341b92a7af2bb698e9e024"},
-    {file = "mongo_charms_single_kernel-1.8.2.tar.gz", hash = "sha256:505f618e8e482ad13cdb1d2c31970cd7f8298cd5f808cb7b3134d882a833fbe1"},
+    {file = "mongo_charms_single_kernel-1.8.3-py3-none-any.whl", hash = "sha256:7fd5062fec04ba022c1e1547cdbe4283ac01e8b015e0f53ef628541b5ace20b9"},
+    {file = "mongo_charms_single_kernel-1.8.3.tar.gz", hash = "sha256:30474d3d000a9caa38f5f8aa3562fc2f211e93a929cda00bce75ee73aa7d7716"},
 ]
 
 [package.dependencies]
@@ -2845,4 +2845,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "d2f240409443e968a335bec5ff62f63a13a07345c203d957e767f8930cf1bcdc"
+content-hash = "1d48c24c248adb86a50569201be9179d8f97693c8936c40698b149822f65bbc3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-poetry = ">=2.0.0"
 
 [tool.poetry.dependencies]
 python = "^3.10.12"
-mongo-charms-single-kernel = "1.8.2"
+mongo-charms-single-kernel = "1.8.3"
 ops = ">=2.21"
 pymongo = "^4.7.3"
 overrides = "^7.7.0"
@@ -43,7 +43,7 @@ ruff = "^0.1.6"
 codespell = "^2.2.6"
 
 [tool.poetry.group.unit.dependencies]
-mongo-charms-single-kernel = "1.8.2"
+mongo-charms-single-kernel = "1.8.3"
 coverage = {extras = ["toml"], version = "^7.5.0"}
 pytest = "^8.1.1"
 pytest-mock = "*"
@@ -51,7 +51,7 @@ parameterized = "^0.9.0"
 pymongo = "^4.7.3"
 
 [tool.poetry.group.integration.dependencies]
-mongo-charms-single-kernel = "1.8.2"
+mongo-charms-single-kernel = "1.8.3"
 allure-pytest = "^2.13.5"
 ops = ">=2.21"
 pymongo = "^4.7.3"


### PR DESCRIPTION
The mongo-single-kernel now includes internal user password management by config option (https://github.com/canonical/mongo-single-kernel-library/pull/83)