### PR TITLE
patch: bump mongo-single-kernel-library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1375,14 +1375,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.7.2"
+version = "1.7.3"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration", "unit"]
 files = [
-    {file = "mongo_charms_single_kernel-1.7.2-py3-none-any.whl", hash = "sha256:f1ae5de40afbba43a3caa1ed26c616672b5f81be974eb3f8d9da5eae6e6c5b33"},
-    {file = "mongo_charms_single_kernel-1.7.2.tar.gz", hash = "sha256:ddf7dddc0d8e33794dcbe199e4dab1d710b765ba852343e80e464896308cf94b"},
+    {file = "mongo_charms_single_kernel-1.7.3-py3-none-any.whl", hash = "sha256:f246201cafd185de73612ecbd624b0bb8a983c905236f05237dc4889270dc49e"},
+    {file = "mongo_charms_single_kernel-1.7.3.tar.gz", hash = "sha256:208ac2180ec78f746b04253890a0da89e58944d4e0ed0d14c19272b77d76e0be"},
 ]
 
 [package.dependencies]
@@ -2845,4 +2845,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "33708776a756a4b5436a567bef030fe4a2b321efd6e5f13354d538d578eb1b83"
+content-hash = "bf2cde5c7a4bab0adf96a9ba6f7dd9a952aa46259f3704a51fdf9b20b2846ec0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-poetry = ">=2.0.0"
 
 [tool.poetry.dependencies]
 python = "^3.10.12"
-mongo-charms-single-kernel = "1.7.2"
+mongo-charms-single-kernel = "1.7.3"
 ops = ">=2.21"
 pymongo = "^4.7.3"
 overrides = "^7.7.0"
@@ -43,7 +43,7 @@ ruff = "^0.1.6"
 codespell = "^2.2.6"
 
 [tool.poetry.group.unit.dependencies]
-mongo-charms-single-kernel = "1.7.2"
+mongo-charms-single-kernel = "1.7.3"
 coverage = {extras = ["toml"], version = "^7.5.0"}
 pytest = "^8.1.1"
 pytest-mock = "*"
@@ -51,7 +51,7 @@ parameterized = "^0.9.0"
 pymongo = "^4.7.3"
 
 [tool.poetry.group.integration.dependencies]
-mongo-charms-single-kernel = "1.7.2"
+mongo-charms-single-kernel = "1.7.3"
 allure-pytest = "^2.13.5"
 ops = ">=2.21"
 pymongo = "^4.7.3"


### PR DESCRIPTION
The mongo-single-kernel now includes internal user password management by config option (https://github.com/canonical/mongo-single-kernel-library/pull/88)
