### PR TITLE
patch: bump mongo-single-kernel library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1271,14 +1271,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.3"
+version = "1.8.5"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.3-py3-none-any.whl", hash = "sha256:7fd5062fec04ba022c1e1547cdbe4283ac01e8b015e0f53ef628541b5ace20b9"},
-    {file = "mongo_charms_single_kernel-1.8.3.tar.gz", hash = "sha256:30474d3d000a9caa38f5f8aa3562fc2f211e93a929cda00bce75ee73aa7d7716"},
+    {file = "mongo_charms_single_kernel-1.8.5-py3-none-any.whl", hash = "sha256:d5c104634fc05be6b044ad6e1eba2c528e4247f62f1d5b7f696d725b5d6f6ce9"},
+    {file = "mongo_charms_single_kernel-1.8.5.tar.gz", hash = "sha256:85f70df2150f0394f7fe570a923f63bfb877d472db2c4f0ef213b5d8b6212826"},
 ]
 
 [package.dependencies]
@@ -2708,4 +2708,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "07fb847283073c65e09ccdbfd3f3b9d12b4b569faa04aa48b5c232c953cc27ea"
+content-hash = "4ccc5886724ded23e5b84e05ee2c8c973062e563dc283bba2e9d2f3376ce8b3c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-poetry = ">=2.0.0"
 
 [tool.poetry.dependencies]
 python = "^3.10.12"
-mongo-charms-single-kernel = "1.8.3"
+mongo-charms-single-kernel = "1.8.5"
 ops = ">=2.21"
 pymongo = "^4.7.3"
 overrides = "^7.7.0"
@@ -43,7 +43,7 @@ ruff = "^0.1.6"
 codespell = "^2.2.6"
 
 [tool.poetry.group.integration.dependencies]
-mongo-charms-single-kernel = "1.8.3"
+mongo-charms-single-kernel = "1.8.5"
 allure-pytest = "^2.13.5"
 ops = ">=2.21"
 pymongo = "^4.7.3"


### PR DESCRIPTION
Bump mongo-single-kernel library. This version includes the separation of volumes