### PR TITLE
patch: Bump mongo-charms-single-kernel to v1.8.18

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -77,7 +77,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/poetry.lock
+++ b/poetry.lock
@@ -1455,14 +1455,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.16"
+version = "1.8.18"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.16-py3-none-any.whl", hash = "sha256:38f9bee829e71481191cb5b92f0cc96fe0fa0ceb449b40ab2f04a4cd0bd31068"},
-    {file = "mongo_charms_single_kernel-1.8.16.tar.gz", hash = "sha256:01c1f3d4ba60588e56370416370b029b7208cb7965836af72a942a1e3cf03610"},
+    {file = "mongo_charms_single_kernel-1.8.18-py3-none-any.whl", hash = "sha256:54187acd4fe2b2d9402a0f26fb89f7a0455396590285a2e7151fc79d43530c0e"},
+    {file = "mongo_charms_single_kernel-1.8.18.tar.gz", hash = "sha256:2ace3e23ce8bc559b10e5db11d7d60bba952ddc686221c2d89772384c5e6795a"},
 ]
 
 [package.dependencies]
@@ -2983,4 +2983,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "b9faf550f436817dd9c74de435d0f283712145947eff76c75a0d68e6b1595b0f"
+content-hash = "f069fe5cc2157ba271cbf9616c96a5321d5c6646414c92058748dfec09d0c77a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires-poetry = ">=2.0.0"
 
 [tool.poetry.dependencies]
 python = "^3.10.12"
-mongo-charms-single-kernel = "1.8.16"
 ops = ">=2.21"
 pymongo = "^4.7.3"
 overrides = "^7.7.0"
@@ -19,6 +18,7 @@ pure-sasl = ">=0.6.2"
 poetry-core = "^2.0"
 rpds-py = "0.18.0"
 lightkube = "^0.15.3"
+mongo-charms-single-kernel = "v1.8.18"
 
 [tool.poetry.group.charm-libs.dependencies]
 ops = ">=2.21"
@@ -51,7 +51,6 @@ codespell = "^2.2.6"
 
 [tool.poetry.group.integration.dependencies]
 lightkube = "^0.15.3"
-mongo-charms-single-kernel = "1.8.16"
 allure-pytest = "^2.13.5"
 ops = ">=2.21"
 pymongo = "^4.7.3"
@@ -61,6 +60,7 @@ pytest-asyncio ="^0.21.1"
 pytest-operator = "^0.34.0"
 pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
 allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
+mongo-charms-single-kernel = "v1.8.18"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Automated bump of `mongo-charms-single-kernel` to version `v1.8.18` after PyPI release.