### PR TITLE
patch: Bump mongo-charms-single-kernel to v1.8.19

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1455,14 +1455,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.18"
+version = "1.8.19"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.18-py3-none-any.whl", hash = "sha256:54187acd4fe2b2d9402a0f26fb89f7a0455396590285a2e7151fc79d43530c0e"},
-    {file = "mongo_charms_single_kernel-1.8.18.tar.gz", hash = "sha256:2ace3e23ce8bc559b10e5db11d7d60bba952ddc686221c2d89772384c5e6795a"},
+    {file = "mongo_charms_single_kernel-1.8.19-py3-none-any.whl", hash = "sha256:6930c0efc6032aef107f0c61031f2b5670e37f270187be54749af389cdf0553f"},
+    {file = "mongo_charms_single_kernel-1.8.19.tar.gz", hash = "sha256:ed67da0d7ebfb69c90a0d815ef08fd0f67b3d9a3a29a376e39ae115a0de2ad2e"},
 ]
 
 [package.dependencies]
@@ -2983,4 +2983,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "f069fe5cc2157ba271cbf9616c96a5321d5c6646414c92058748dfec09d0c77a"
+content-hash = "989cfe5c483083886aec1696f490672f893f6d861d2cc473f82f04f7cf0bedb3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ pure-sasl = ">=0.6.2"
 poetry-core = "^2.0"
 rpds-py = "0.18.0"
 lightkube = "^0.15.3"
-mongo-charms-single-kernel = "v1.8.18"
+mongo-charms-single-kernel = "v1.8.19"
 
 [tool.poetry.group.charm-libs.dependencies]
 ops = ">=2.21"
@@ -60,7 +60,7 @@ pytest-asyncio ="^0.21.1"
 pytest-operator = "^0.34.0"
 pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
 allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
-mongo-charms-single-kernel = "v1.8.18"
+mongo-charms-single-kernel = "v1.8.19"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Automated bump of `mongo-charms-single-kernel` to version `v1.8.19` after PyPI release.