### PR TITLE
patch: Bump mongo-charms-single-kernel to version v1.8.22

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1455,14 +1455,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.19"
+version = "1.8.22"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.19-py3-none-any.whl", hash = "sha256:6930c0efc6032aef107f0c61031f2b5670e37f270187be54749af389cdf0553f"},
-    {file = "mongo_charms_single_kernel-1.8.19.tar.gz", hash = "sha256:ed67da0d7ebfb69c90a0d815ef08fd0f67b3d9a3a29a376e39ae115a0de2ad2e"},
+    {file = "mongo_charms_single_kernel-1.8.22-py3-none-any.whl", hash = "sha256:3d2e381dead393496c9489775afcf37ab63e917916c0a204bac01b47b47c0523"},
+    {file = "mongo_charms_single_kernel-1.8.22.tar.gz", hash = "sha256:d1d05842dd69b9e96e6fa58405b5e39e72a7faf82baac38ab3143bbb8732e3bb"},
 ]
 
 [package.dependencies]
@@ -2983,4 +2983,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "989cfe5c483083886aec1696f490672f893f6d861d2cc473f82f04f7cf0bedb3"
+content-hash = "6efba7685b1f21d4aae126966a4ba2c6ed235141f37577eec364c5a8a60ad1e0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ pure-sasl = ">=0.6.2"
 poetry-core = "^2.0"
 rpds-py = "0.18.0"
 lightkube = "^0.15.3"
-mongo-charms-single-kernel = "v1.8.19"
+mongo-charms-single-kernel = "v1.8.22"
 
 [tool.poetry.group.charm-libs.dependencies]
 ops = ">=2.21"
@@ -60,7 +60,7 @@ pytest-asyncio ="^0.21.1"
 pytest-operator = "^0.34.0"
 pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
 allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
-mongo-charms-single-kernel = "v1.8.19"
+mongo-charms-single-kernel = "v1.8.22"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Automated bump of mongo-charms-single-kernel to version v1.8.22 after PyPI release.

Includes:

- patch: add scheduler for TICS workflow in 6/edge by @patriciareinoso in https://github.com/canonical/mongo-single-kernel-library/pull/178
- patch: add workflow dispatch for bump library in charm repos workflow by @patriciareinoso in https://github.com/canonical/mongo-single-kernel-library/pull/167
- patch: validate private key matches certificate and config by @patriciareinoso in https://github.com/canonical/mongo-single-kernel-library/pull/177